### PR TITLE
Use print() function in both Python 2 and Python 3

### DIFF
--- a/filebeat/scripts/filebeat-clean-zeeklogs-processed-folder.py
+++ b/filebeat/scripts/filebeat-clean-zeeklogs-processed-folder.py
@@ -3,6 +3,7 @@
 # Copyright (c) 2019 Battelle Energy Alliance, LLC.  All rights reserved.
 
 
+from __future__ import print_function
 import os
 from os.path import splitext
 import errno
@@ -94,14 +95,14 @@ def pruneFiles():
 
       if (cleanSeconds > 0) and (lastUseTime >= cleanSeconds):
         # this is a closed file that is old, so delete it
-        print "removing old file \"{}\" ({}, used {} seconds ago)".format(file, fileType, lastUseTime)
+        print("removing old file \"{}\" ({}, used {} seconds ago)".format(file, fileType, lastUseTime))
         silentRemove(file)
 
   # clean up any broken symlinks in the current/ directory
   for current in os.listdir(currentDir):
     currentFileSpec = os.path.join(currentDir, current)
     if os.path.islink(currentFileSpec) and not os.path.exists(currentFileSpec):
-      print "removing dead symlink \"{}\"".format(currentFileSpec)
+      print("removing dead symlink \"{}\"".format(currentFileSpec))
       silentRemove(currentFileSpec)
 
   # clean up any old and empty directories in processed/ directory
@@ -119,7 +120,7 @@ def pruneFiles():
     if (dirAge >= cleanDirSeconds):
       try:
         os.rmdir(dirToRm)
-        print "removed empty directory \"{}\" (used {} seconds ago)".format(dirToRm, dirAge)
+        print("removed empty directory \"{}\" (used {} seconds ago)".format(dirToRm, dirAge))
       except OSError:
         pass
 

--- a/filebeat/scripts/zeek-log-field-bitmap.py
+++ b/filebeat/scripts/zeek-log-field-bitmap.py
@@ -49,6 +49,11 @@ import json
 from collections import defaultdict
 from ordered_set import OrderedSet
 
+try:
+  basestring
+except NameError:  # Python 3
+  basestring = str
+
 # lists of all known fields for each type of zeek log we're concerned with mapping (ordered as in the .log file header)
 # are stored in zeek-log-fields.json
 FIELDS_JSON_FILE = os.path.join(os.path.dirname(os.path.realpath(__file__)), "zeek-log-fields.json")
@@ -87,9 +92,9 @@ def main():
   # load from json canonical list of known zeek log fields we're concerned with mapping
   try:
     zeekLogFieldsTmp = json.load(open(FIELDS_JSON_FILE, 'r'))
-    if type(zeekLogFieldsTmp) is dict:
+    if isinstance(zeekLogFieldsTmp, dict):
       for logType, listOfFieldLists in zeekLogFieldsTmp.items():
-        if ((type(logType) is str) or (type(logType) is unicode)) and type(listOfFieldLists) is list:
+        if isinstance(logType, basestring) and isinstance(listOfFieldLists, list):
           zeekLogFields[str(logType)] = [OrderedSet(fieldList) for fieldList in listOfFieldLists]
         else:
           dataError = True


### PR DESCRIPTION
Legacy __print__ statements are syntax errors in Python 3 but __print()__ function works as expected in both Python 2 and Python 3.