### PR TITLE
Ignore permissions complaint for filebeat.yml when starting up filebe…

### DIFF
--- a/filebeat/supervisord.conf
+++ b/filebeat/supervisord.conf
@@ -17,7 +17,7 @@ supervisor.rpcinterface_factory=supervisor.rpcinterface:make_main_rpcinterface
 serverurl=unix:///var/run/supervisor.sock
 
 [program:filebeat]
-command=/usr/local/bin/docker-entrypoint -e
+command=/usr/local/bin/docker-entrypoint -e --strict.perms=false
 user=filebeat
 startsecs=0
 startretries=0


### PR DESCRIPTION
…at. As we're inside a container anyway we don't care about strict permissions checking. Addresses issue #24.