### PR TITLE
provide directory to put CA certificates for trusted LDAP servers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@
 /logstash/certs
 /filebeat/certs
 /nginx/certs
+/nginx/ca-trust
 /nginx/htpasswd
 /nginx/nginx_ldap.conf
 /htadmin/config.ini

--- a/Dockerfiles/nginx.Dockerfile
+++ b/Dockerfiles/nginx.Dockerfile
@@ -61,10 +61,22 @@ ARG NGINX_LDAP_TLS_STUNNEL=false
 # when initiating the "extendedReq(1) LDAP_START_TLS_OID" command, which protocol to use: winldap or openldap
 ARG NGINX_LDAP_TLS_STUNNEL_PROTOCOL=winldap
 
+# stunnel will require and verify certificates for StartTLS when one or more
+# trusted CA certificate files are placed in the ./nginx/ca-trust directory.
+# For additional security, hostname or IP address checking of the associated
+# CA certificate(s) can be enabled by providing these values.
+# see https://www.stunnel.org/howto.html
+#     https://www.openssl.org/docs/man1.1.1/man3/X509_check_host.html
+ARG NGINX_LDAP_TLS_STUNNEL_CHECK_HOST=
+ARG NGINX_LDAP_TLS_STUNNEL_CHECK_IP=
+ARG NGINX_LDAP_TLS_STUNNEL_VERIFY_LEVEL=2
+
 ENV NGINX_BASIC_AUTH $NGINX_BASIC_AUTH
 ENV NGINX_LDAP_TLS_STUNNEL $NGINX_LDAP_TLS_STUNNEL
 ENV NGINX_LDAP_TLS_STUNNEL_PROTOCOL $NGINX_LDAP_TLS_STUNNEL_PROTOCOL
-
+ENV NGINX_LDAP_TLS_STUNNEL_CHECK_HOST $NGINX_LDAP_TLS_STUNNEL_CHECK_HOST
+ENV NGINX_LDAP_TLS_STUNNEL_CHECK_IP $NGINX_LDAP_TLS_STUNNEL_CHECK_IP
+ENV NGINX_LDAP_TLS_STUNNEL_VERIFY_LEVEL $NGINX_LDAP_TLS_STUNNEL_VERIFY_LEVEL
 
 # build latest nginx with nginx-auth-ldap
 ENV NGINX_VERSION=1.17.9

--- a/Dockerfiles/nginx.Dockerfile
+++ b/Dockerfiles/nginx.Dockerfile
@@ -81,10 +81,8 @@ ENV NGINX_LDAP_TLS_STUNNEL_VERIFY_LEVEL $NGINX_LDAP_TLS_STUNNEL_VERIFY_LEVEL
 # build latest nginx with nginx-auth-ldap
 ENV NGINX_VERSION=1.17.9
 ENV NGINX_AUTH_LDAP_BRANCH=master
-ENV NGINX_AUTH_PAM_BRANCH=master
 
 ADD https://codeload.github.com/mmguero-dev/nginx-auth-ldap/tar.gz/$NGINX_AUTH_LDAP_BRANCH /nginx-auth-ldap.tar.gz
-ADD https://codeload.github.com/sto/ngx_http_auth_pam_module/tar.gz/$NGINX_AUTH_PAM_BRANCH /ngx_http_auth_pam_module.tar.gz
 ADD http://nginx.org/download/nginx-$NGINX_VERSION.tar.gz /nginx.tar.gz
 
 COPY --from=stunnel_build /apkbuild/packages/community/x86_64/stunnel-*.apk /tmp/
@@ -136,7 +134,6 @@ RUN set -x ; \
     --with-file-aio \
     --with-http_v2_module \
     --add-module=/usr/src/nginx-auth-ldap \
-    --add-module=/usr/src/ngx_http_auth_pam_module \
   " ; \
   addgroup -g 101 -S nginx ; \
   adduser -S -D -H -u 101 -h /var/cache/nginx -s /sbin/nologin -G nginx -g nginx nginx ; \
@@ -155,17 +152,15 @@ RUN set -x ; \
     linux-headers \
     make \
     openldap-dev \
-    linux-pam-dev \
     pcre-dev \
     perl-dev \
     tar \
     zlib-dev \
     ; \
     \
-  mkdir -p /usr/src/nginx-auth-ldap /usr/src/ngx_http_auth_pam_module /www /www/logs/nginx ; \
+  mkdir -p /usr/src/nginx-auth-ldap /www /www/logs/nginx ; \
   tar -zxC /usr/src -f /nginx.tar.gz ; \
   tar -zxC /usr/src/nginx-auth-ldap --strip=1 -f /nginx-auth-ldap.tar.gz ; \
-  tar -zxC /usr/src/ngx_http_auth_pam_module --strip=1 -f /ngx_http_auth_pam_module.tar.gz ; \
   cd /usr/src/nginx-$NGINX_VERSION ; \
   ./configure $CONFIG --with-debug ; \
   make -j$(getconf _NPROCESSORS_ONLN) ; \
@@ -208,14 +203,14 @@ RUN set -x ; \
       | xargs -r apk info --installed \
       | sort -u \
   )" ; \
-  apk add --no-cache --virtual .nginx-rundeps $runDeps ca-certificates bash wget openssl apache2-utils openldap linux-pam nss-pam-ldapd supervisor tzdata; \
+  apk add --no-cache --virtual .nginx-rundeps $runDeps ca-certificates bash wget openssl apache2-utils openldap supervisor tzdata; \
   update-ca-certificates; \
   apk add --no-cache --allow-untrusted /tmp/stunnel-*.apk; \
   apk del .nginx-build-deps ; \
   apk del .gettext ; \
   mv /tmp/envsubst /usr/local/bin/ ; \
   mkdir -p /var/log/supervisor ; \
-  rm -rf /usr/src/* /var/tmp/* /var/cache/apk/* /tmp/stunnel-*.apk /nginx.tar.gz /nginx-auth-ldap.tar.gz /ngx_http_auth_pam_module.tar.gz; \
+  rm -rf /usr/src/* /var/tmp/* /var/cache/apk/* /tmp/stunnel-*.apk /nginx.tar.gz /nginx-auth-ldap.tar.gz; \
   touch /etc/nginx/nginx_ldap.conf /etc/nginx/nginx_blank.conf;
 
 COPY --from=jwilder/nginx-proxy:alpine /app/nginx.tmpl /etc/nginx/

--- a/README.md
+++ b/README.md
@@ -757,6 +757,8 @@ In addition to the `NGINX_BASIC_AUTH` environment variable being set to `false` 
     - `NGINX_LDAP_TLS_STUNNEL` set to `false` in [`docker-compose.yml`](#DockerComposeYml)
     - `url` should begin with `ldap://` and its port should be either the default LDAP port (389) or the default Global Catalog port (3268) in `nginx/nginx_ldap.conf` 
 
+For encrypted connections (whether using **StartTLS** or **LDAPS**), Malcolm will require and verify certificates when one or more trusted CA certificate files are placed in the `nginx/ca-trust/` directory. Otherwise, any certificate presented by the domain server will be accepted.
+
 ### <a name="Starting"></a>Starting Malcolm
 
 [Docker compose](https://docs.docker.com/compose/) is used to coordinate running the Docker containers. To start Malcolm, navigate to the directory containing `docker-compose.yml` and run:

--- a/README.md
+++ b/README.md
@@ -128,21 +128,21 @@ You can then observe that the images have been retrieved by running `docker imag
 ```
 $ docker images
 REPOSITORY                                          TAG                 IMAGE ID            CREATED             SIZE
-malcolmnetsec/moloch                                2.0.2               xxxxxxxxxxxx        10 minutes ago      491MB
-malcolmnetsec/logstash-oss                          2.0.2               xxxxxxxxxxxx        17 minutes ago      1.4GB
-malcolmnetsec/zeek                                  2.0.2               xxxxxxxxxxxx        17 minutes ago      232MB
-malcolmnetsec/file-upload                           2.0.2               xxxxxxxxxxxx        23 minutes ago      199MB
-malcolmnetsec/pcap-capture                          2.0.2               xxxxxxxxxxxx        23 minutes ago      112MB
-malcolmnetsec/file-monitor                          2.0.2               xxxxxxxxxxxx        25 minutes ago      369MB
-malcolmnetsec/filebeat-oss                          2.0.2               xxxxxxxxxxxx        28 minutes ago      501MB
-malcolmnetsec/kibana-oss                            2.0.2               xxxxxxxxxxxx        28 minutes ago      964MB
-malcolmnetsec/pcap-monitor                          2.0.2               xxxxxxxxxxxx        28 minutes ago      156MB
-malcolmnetsec/curator                               2.0.2               xxxxxxxxxxxx        29 minutes ago      240MB
-malcolmnetsec/nginx-proxy                           2.0.2               xxxxxxxxxxxx        29 minutes ago      54.5MB
-malcolmnetsec/elastalert                            2.0.2               xxxxxxxxxxxx        30 minutes ago      276MB
-malcolmnetsec/htadmin                               2.0.2               xxxxxxxxxxxx        31 minutes ago      256MB
-malcolmnetsec/freq                                  2.0.2               xxxxxxxxxxxx        32 minutes ago      188MB
-malcolmnetsec/name-map-ui                           2.0.2               xxxxxxxxxxxx        35 minutes ago      20MB
+malcolmnetsec/moloch                                2.0.3               xxxxxxxxxxxx        10 minutes ago      491MB
+malcolmnetsec/logstash-oss                          2.0.3               xxxxxxxxxxxx        17 minutes ago      1.4GB
+malcolmnetsec/zeek                                  2.0.3               xxxxxxxxxxxx        17 minutes ago      232MB
+malcolmnetsec/file-upload                           2.0.3               xxxxxxxxxxxx        23 minutes ago      199MB
+malcolmnetsec/pcap-capture                          2.0.3               xxxxxxxxxxxx        23 minutes ago      112MB
+malcolmnetsec/file-monitor                          2.0.3               xxxxxxxxxxxx        25 minutes ago      369MB
+malcolmnetsec/filebeat-oss                          2.0.3               xxxxxxxxxxxx        28 minutes ago      501MB
+malcolmnetsec/kibana-oss                            2.0.3               xxxxxxxxxxxx        28 minutes ago      964MB
+malcolmnetsec/pcap-monitor                          2.0.3               xxxxxxxxxxxx        28 minutes ago      156MB
+malcolmnetsec/curator                               2.0.3               xxxxxxxxxxxx        29 minutes ago      240MB
+malcolmnetsec/nginx-proxy                           2.0.3               xxxxxxxxxxxx        29 minutes ago      54.5MB
+malcolmnetsec/elastalert                            2.0.3               xxxxxxxxxxxx        30 minutes ago      276MB
+malcolmnetsec/htadmin                               2.0.3               xxxxxxxxxxxx        31 minutes ago      256MB
+malcolmnetsec/freq                                  2.0.3               xxxxxxxxxxxx        32 minutes ago      188MB
+malcolmnetsec/name-map-ui                           2.0.3               xxxxxxxxxxxx        35 minutes ago      20MB
 docker.elastic.co/elasticsearch/elasticsearch-oss   7.6.2               xxxxxxxxxxxx        5 weeks ago         825MB
 ```
 
@@ -1375,7 +1375,7 @@ Building the ISO may take 30 minutes or more depending on your system. As the bu
 
 ```
 …
-Finished, created "/malcolm-build/malcolm-iso/malcolm-2.0.2.iso"
+Finished, created "/malcolm-build/malcolm-iso/malcolm-2.0.3.iso"
 …
 ```
 
@@ -1771,21 +1771,21 @@ Pulling zeek          ... done
 
 user@host:~/Malcolm$ docker images
 REPOSITORY                                          TAG                 IMAGE ID            CREATED             SIZE
-malcolmnetsec/moloch                                2.0.2               xxxxxxxxxxxx        27 minutes ago      517MB
-malcolmnetsec/zeek                                  2.0.2               xxxxxxxxxxxx        27 minutes ago      489MB
-malcolmnetsec/htadmin                               2.0.2               xxxxxxxxxxxx        2 hours ago         180MB
-malcolmnetsec/nginx-proxy                           2.0.2               xxxxxxxxxxxx        4 hours ago         53MB
-malcolmnetsec/file-upload                           2.0.2               xxxxxxxxxxxx        24 hours ago        198MB
-malcolmnetsec/pcap-capture                          2.0.2               xxxxxxxxxxxx        24 hours ago        111MB
-malcolmnetsec/pcap-monitor                          2.0.2               xxxxxxxxxxxx        24 hours ago        156MB
-malcolmnetsec/file-monitor                          2.0.2               xxxxxxxxxxxx        24 hours ago        355MB
-malcolmnetsec/logstash-oss                          2.0.2               xxxxxxxxxxxx        25 hours ago        1.24GB
-malcolmnetsec/curator                               2.0.2               xxxxxxxxxxxx        25 hours ago        303MB
-malcolmnetsec/kibana-oss                            2.0.2               xxxxxxxxxxxx        33 hours ago        944MB
-malcolmnetsec/filebeat-oss                          2.0.2               xxxxxxxxxxxx        11 days ago         459MB
-malcolmnetsec/elastalert                            2.0.2               xxxxxxxxxxxx        11 days ago         276MB
-malcolmnetsec/freq                                  2.0.2               xxxxxxxxxxxx        11 days ago         188MB
-malcolmnetsec/name-map-ui                           2.0.2               xxxxxxxxxxxx        35 minutes ago      20MB
+malcolmnetsec/moloch                                2.0.3               xxxxxxxxxxxx        27 minutes ago      517MB
+malcolmnetsec/zeek                                  2.0.3               xxxxxxxxxxxx        27 minutes ago      489MB
+malcolmnetsec/htadmin                               2.0.3               xxxxxxxxxxxx        2 hours ago         180MB
+malcolmnetsec/nginx-proxy                           2.0.3               xxxxxxxxxxxx        4 hours ago         53MB
+malcolmnetsec/file-upload                           2.0.3               xxxxxxxxxxxx        24 hours ago        198MB
+malcolmnetsec/pcap-capture                          2.0.3               xxxxxxxxxxxx        24 hours ago        111MB
+malcolmnetsec/pcap-monitor                          2.0.3               xxxxxxxxxxxx        24 hours ago        156MB
+malcolmnetsec/file-monitor                          2.0.3               xxxxxxxxxxxx        24 hours ago        355MB
+malcolmnetsec/logstash-oss                          2.0.3               xxxxxxxxxxxx        25 hours ago        1.24GB
+malcolmnetsec/curator                               2.0.3               xxxxxxxxxxxx        25 hours ago        303MB
+malcolmnetsec/kibana-oss                            2.0.3               xxxxxxxxxxxx        33 hours ago        944MB
+malcolmnetsec/filebeat-oss                          2.0.3               xxxxxxxxxxxx        11 days ago         459MB
+malcolmnetsec/elastalert                            2.0.3               xxxxxxxxxxxx        11 days ago         276MB
+malcolmnetsec/freq                                  2.0.3               xxxxxxxxxxxx        11 days ago         188MB
+malcolmnetsec/name-map-ui                           2.0.3               xxxxxxxxxxxx        35 minutes ago      20MB
 docker.elastic.co/elasticsearch/elasticsearch-oss   7.6.2               xxxxxxxxxxxx        5 weeks ago         769MB
 ```
 

--- a/docker-compose-standalone.yml
+++ b/docker-compose-standalone.yml
@@ -15,6 +15,13 @@ x-auth-variables: &auth-variables
   # When NGINX_LDAP_TLS_STUNNEL=true, which protocol to use when initiating the
   # "extendedReq(1) LDAP_START_TLS_OID" command: winldap or openldap
   NGINX_LDAP_TLS_STUNNEL_PROTOCOL : 'winldap'
+  # stunnel will require and verify certificates for StartTLS when one or more
+  # trusted CA certificate files are placed in the ./nginx/ca-trust directory.
+  # For additional security, hostname or IP address checking of the associated
+  # CA certificate(s) can be enabled by providing these values.
+  NGINX_LDAP_TLS_STUNNEL_CHECK_HOST : ''
+  NGINX_LDAP_TLS_STUNNEL_CHECK_IP : ''
+  NGINX_LDAP_TLS_STUNNEL_VERIFY_LEVEL : 2
 
 x-nginx-variables: &nginx-variables
   # Whether or not to write nginx's access.log and error.log to Elasticsearch
@@ -473,6 +480,7 @@ services:
       - nginx-log-path:/var/log/nginx:rw
       - ./nginx/nginx_ldap.conf:/etc/nginx/nginx_ldap.conf:ro
       - ./nginx/htpasswd:/etc/nginx/.htpasswd:ro
+      - ./nginx/ca-trust:/etc/nginx/ca-trust:ro
       - ./nginx/certs:/etc/nginx/certs:ro
       - ./nginx/certs/dhparam.pem:/etc/nginx/dhparam/dhparam.pem:ro
     healthcheck:

--- a/docker-compose-standalone.yml
+++ b/docker-compose-standalone.yml
@@ -134,7 +134,7 @@ services:
       retries: 3
       start_period: 180s
   kibana:
-    image: malcolmnetsec/kibana-oss:2.0.2
+    image: malcolmnetsec/kibana-oss:2.0.3
     restart: "no"
     hostname: kibana
     environment:
@@ -157,7 +157,7 @@ services:
       retries: 3
       start_period: 210s
   elastalert:
-    image: malcolmnetsec/elastalert:2.0.2
+    image: malcolmnetsec/elastalert:2.0.3
     restart: "no"
     hostname: elastalert
     environment:
@@ -182,7 +182,7 @@ services:
       retries: 3
       start_period: 210s
   curator:
-    image: malcolmnetsec/curator:2.0.2
+    image: malcolmnetsec/curator:2.0.3
     restart: "no"
     hostname: curator
     environment:
@@ -198,7 +198,7 @@ services:
       retries: 3
       start_period: 30s
   logstash:
-    image: malcolmnetsec/logstash-oss:2.0.2
+    image: malcolmnetsec/logstash-oss:2.0.3
     restart: "no"
     hostname: logstash
     environment:
@@ -228,7 +228,7 @@ services:
       retries: 3
       start_period: 600s
   filebeat:
-    image: malcolmnetsec/filebeat-oss:2.0.2
+    image: malcolmnetsec/filebeat-oss:2.0.3
     restart: "no"
     hostname: filebeat
     environment:
@@ -262,7 +262,7 @@ services:
       retries: 3
       start_period: 60s
   moloch:
-    image: malcolmnetsec/moloch:2.0.2
+    image: malcolmnetsec/moloch:2.0.3
     restart: "no"
     hostname: moloch
     env_file:
@@ -298,7 +298,7 @@ services:
       retries: 3
       start_period: 210s
   zeek:
-    image: malcolmnetsec/zeek:2.0.2
+    image: malcolmnetsec/zeek:2.0.3
     restart: "no"
     hostname: zeek
     environment:
@@ -321,7 +321,7 @@ services:
       retries: 3
       start_period: 60s
   file-monitor:
-    image: malcolmnetsec/file-monitor:2.0.2
+    image: malcolmnetsec/file-monitor:2.0.3
     restart: "no"
     hostname: filemon
     environment:
@@ -338,7 +338,7 @@ services:
       retries: 3
       start_period: 60s
   pcap-capture:
-    image: malcolmnetsec/pcap-capture:2.0.2
+    image: malcolmnetsec/pcap-capture:2.0.3
     restart: "no"
     network_mode: host
     ulimits:
@@ -361,7 +361,7 @@ services:
       retries: 3
       start_period: 60s
   pcap-monitor:
-    image: malcolmnetsec/pcap-monitor:2.0.2
+    image: malcolmnetsec/pcap-monitor:2.0.3
     restart: "no"
     hostname: pcapmon
     environment:
@@ -381,7 +381,7 @@ services:
       retries: 3
       start_period: 90s
   upload:
-    image: malcolmnetsec/file-upload:2.0.2
+    image: malcolmnetsec/file-upload:2.0.3
     restart: "no"
     hostname: upload
     env_file:
@@ -404,7 +404,7 @@ services:
       retries: 3
       start_period: 60s
   htadmin:
-    image: malcolmnetsec/htadmin:2.0.2
+    image: malcolmnetsec/htadmin:2.0.3
     restart: "no"
     hostname: htadmin
     environment:
@@ -423,7 +423,7 @@ services:
       retries: 3
       start_period: 60s
   freq:
-    image: malcolmnetsec/freq:2.0.2
+    image: malcolmnetsec/freq:2.0.3
     restart: "no"
     hostname: freq
     environment:
@@ -438,7 +438,7 @@ services:
       retries: 3
       start_period: 60s
   name-map-ui:
-    image: malcolmnetsec/name-map-ui:2.0.2
+    image: malcolmnetsec/name-map-ui:2.0.3
     restart: "no"
     hostname: name-map-ui
     environment:
@@ -456,7 +456,7 @@ services:
       retries: 3
       start_period: 60s
   nginx-proxy:
-    image: malcolmnetsec/nginx-proxy:2.0.2
+    image: malcolmnetsec/nginx-proxy:2.0.3
     restart: "no"
     hostname: nginx-proxy
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,13 @@ x-auth-variables: &auth-variables
   # When NGINX_LDAP_TLS_STUNNEL=true, which protocol to use when initiating the
   # "extendedReq(1) LDAP_START_TLS_OID" command: winldap or openldap
   NGINX_LDAP_TLS_STUNNEL_PROTOCOL : 'winldap'
+  # stunnel will require and verify certificates for StartTLS when one or more
+  # trusted CA certificate files are placed in the ./nginx/ca-trust directory.
+  # For additional security, hostname or IP address checking of the associated
+  # CA certificate(s) can be enabled by providing these values.
+  NGINX_LDAP_TLS_STUNNEL_CHECK_HOST : ''
+  NGINX_LDAP_TLS_STUNNEL_CHECK_IP : ''
+  NGINX_LDAP_TLS_STUNNEL_VERIFY_LEVEL : 2
 
 x-nginx-variables: &nginx-variables
   # Whether or not to write nginx's access.log and error.log to Elasticsearch
@@ -528,6 +535,7 @@ services:
       - ./nginx/nginx.conf:/etc/nginx/nginx.conf:ro
       - ./nginx/nginx_ldap.conf:/etc/nginx/nginx_ldap.conf:ro
       - ./nginx/htpasswd:/etc/nginx/.htpasswd:ro
+      - ./nginx/ca-trust:/etc/nginx/ca-trust:ro
       - ./nginx/certs:/etc/nginx/certs:ro
       - ./nginx/certs/dhparam.pem:/etc/nginx/dhparam/dhparam.pem:ro
     healthcheck:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -137,7 +137,7 @@ services:
     build:
       context: .
       dockerfile: Dockerfiles/kibana.Dockerfile
-    image: malcolmnetsec/kibana-oss:2.0.2
+    image: malcolmnetsec/kibana-oss:2.0.3
     restart: "no"
     hostname: kibana
     environment:
@@ -163,7 +163,7 @@ services:
     build:
       context: .
       dockerfile: Dockerfiles/elastalert.Dockerfile
-    image: malcolmnetsec/elastalert:2.0.2
+    image: malcolmnetsec/elastalert:2.0.3
     restart: "no"
     hostname: elastalert
     environment:
@@ -191,7 +191,7 @@ services:
     build:
       context: .
       dockerfile: Dockerfiles/curator.Dockerfile
-    image: malcolmnetsec/curator:2.0.2
+    image: malcolmnetsec/curator:2.0.3
     restart: "no"
     hostname: curator
     environment:
@@ -212,7 +212,7 @@ services:
     build:
       context: .
       dockerfile: Dockerfiles/logstash.Dockerfile
-    image: malcolmnetsec/logstash-oss:2.0.2
+    image: malcolmnetsec/logstash-oss:2.0.3
     restart: "no"
     hostname: logstash
     environment:
@@ -247,7 +247,7 @@ services:
     build:
       context: .
       dockerfile: Dockerfiles/filebeat.Dockerfile
-    image: malcolmnetsec/filebeat-oss:2.0.2
+    image: malcolmnetsec/filebeat-oss:2.0.3
     restart: "no"
     hostname: filebeat
     environment:
@@ -285,7 +285,7 @@ services:
     build:
       context: .
       dockerfile: Dockerfiles/moloch.Dockerfile
-    image: malcolmnetsec/moloch:2.0.2
+    image: malcolmnetsec/moloch:2.0.3
     restart: "no"
     hostname: moloch
     env_file:
@@ -327,7 +327,7 @@ services:
     build:
       context: .
       dockerfile: Dockerfiles/zeek.Dockerfile
-    image: malcolmnetsec/zeek:2.0.2
+    image: malcolmnetsec/zeek:2.0.3
     restart: "no"
     hostname: zeek
     environment:
@@ -354,7 +354,7 @@ services:
     build:
       context: .
       dockerfile: Dockerfiles/file-monitor.Dockerfile
-    image: malcolmnetsec/file-monitor:2.0.2
+    image: malcolmnetsec/file-monitor:2.0.3
     restart: "no"
     hostname: filemon
     environment:
@@ -374,7 +374,7 @@ services:
     build:
       context: .
       dockerfile: Dockerfiles/pcap-capture.Dockerfile
-    image: malcolmnetsec/pcap-capture:2.0.2
+    image: malcolmnetsec/pcap-capture:2.0.3
     restart: "no"
     network_mode: host
     ulimits:
@@ -400,7 +400,7 @@ services:
     build:
       context: .
       dockerfile: Dockerfiles/pcap-monitor.Dockerfile
-    image: malcolmnetsec/pcap-monitor:2.0.2
+    image: malcolmnetsec/pcap-monitor:2.0.3
     restart: "no"
     hostname: pcapmon
     environment:
@@ -423,7 +423,7 @@ services:
     build:
       context: .
       dockerfile: Dockerfiles/file-upload.Dockerfile
-    image: malcolmnetsec/file-upload:2.0.2
+    image: malcolmnetsec/file-upload:2.0.3
     restart: "no"
     hostname: upload
     env_file:
@@ -446,7 +446,7 @@ services:
       retries: 3
       start_period: 60s
   htadmin:
-    image: malcolmnetsec/htadmin:2.0.2
+    image: malcolmnetsec/htadmin:2.0.3
     build:
       context: .
       dockerfile: Dockerfiles/htadmin.Dockerfile
@@ -468,7 +468,7 @@ services:
       retries: 3
       start_period: 60s
   freq:
-    image: malcolmnetsec/freq:2.0.2
+    image: malcolmnetsec/freq:2.0.3
     build:
       context: .
       dockerfile: Dockerfiles/freq.Dockerfile
@@ -486,7 +486,7 @@ services:
       retries: 3
       start_period: 60s
   name-map-ui:
-    image: malcolmnetsec/name-map-ui:2.0.2
+    image: malcolmnetsec/name-map-ui:2.0.3
     build:
       context: .
       dockerfile: Dockerfiles/name-map-ui.Dockerfile
@@ -510,7 +510,7 @@ services:
     build:
       context: .
       dockerfile: Dockerfiles/nginx.Dockerfile
-    image: malcolmnetsec/nginx-proxy:2.0.2
+    image: malcolmnetsec/nginx-proxy:2.0.3
     restart: "no"
     hostname: nginx-proxy
     environment:

--- a/docs/web/conf.py
+++ b/docs/web/conf.py
@@ -1,0 +1,1337 @@
+# -*- coding: utf-8 -*-
+
+import time
+
+# !! This is the configuration of Nikola. !! #
+# !!  You should edit it to your liking.  !! #
+
+
+# ! Some settings can be different in different languages.
+# ! A comment stating (translatable) is used to denote those.
+# ! There are two ways to specify a translatable setting:
+# ! (a) BLOG_TITLE = "My Blog"
+# ! (b) BLOG_TITLE = {"en": "My Blog", "es": "Mi Blog"}
+# ! Option (a) is used when you don't want that setting translated.
+# ! Option (b) is used for settings that are different in different languages.
+
+
+# Data about this site
+BLOG_AUTHOR = "Seth Grover"  # (translatable)
+BLOG_TITLE = "Malcolm"  # (translatable)
+# This is the main URL for your site. It will be used
+# in a prominent link. Don't forget the protocol (http/https)!
+SITE_URL = "https://malcolm.fyi/"
+# This is the URL where Nikola's output will be deployed.
+# If not set, defaults to SITE_URL
+# BASE_URL = "https://malcolm.fyi/"
+BLOG_EMAIL = "malcolm.netsec@gmail.com"
+BLOG_DESCRIPTION = "Malcolm is a powerful, easily deployable network traffic analysis tool suite for full packet capture artifacts (PCAP files) and Zeek logs."  # (translatable)
+
+# Nikola is multilingual!
+#
+# Currently supported languages are:
+#
+# en        English
+# af        Afrikaans
+# ar        Arabic
+# az        Azerbaijani
+# bg        Bulgarian
+# bs        Bosnian
+# ca        Catalan
+# cs        Czech [ALTERNATIVELY cz]
+# da        Danish
+# de        German
+# el        Greek [NOT gr]
+# eo        Esperanto
+# es        Spanish
+# et        Estonian
+# eu        Basque
+# fa        Persian
+# fi        Finnish
+# fr        French
+# fur       Friulian
+# gl        Galician
+# he        Hebrew
+# hi        Hindi
+# hr        Croatian
+# hu        Hungarian
+# ia        Interlingua
+# id        Indonesian
+# it        Italian
+# ja        Japanese [NOT jp]
+# ko        Korean
+# lt        Lithuanian
+# ml        Malayalam
+# nb        Norwegian (Bokmål)
+# nl        Dutch
+# pa        Punjabi
+# pl        Polish
+# pt        Portuguese
+# pt_br     Portuguese (Brazil)
+# ru        Russian
+# sk        Slovak
+# sl        Slovene
+# sq        Albanian
+# sr        Serbian (Cyrillic)
+# sr_latin  Serbian (Latin)
+# sv        Swedish
+# te        Telugu
+# th        Thai
+# tr        Turkish [NOT tr_TR]
+# uk        Ukrainian
+# ur        Urdu
+# vi        Vietnamese
+# zh_cn     Chinese (Simplified)
+# zh_tw     Chinese (Traditional)
+#
+# If you want to use Nikola with a non-supported language you have to provide
+# a module containing the necessary translations
+# (cf. the modules at nikola/data/themes/base/messages/).
+# If a specific post is not translated to a language, then the version
+# in the default language will be shown instead.
+
+# What is the default language?
+DEFAULT_LANG = "en"
+
+# What other languages do you have?
+# The format is {"translationcode" : "path/to/translation" }
+# the path will be used as a prefix for the generated pages location
+TRANSLATIONS = {
+    DEFAULT_LANG: "",
+    # Example for another language:
+    # "es": "./es",
+}
+
+# What will translated input files be named like?
+
+# If you have a page something.rst, then something.pl.rst will be considered
+# its Polish translation.
+#     (in the above example: path == "something", ext == "rst", lang == "pl")
+# this pattern is also used for metadata:
+#     something.meta -> something.pl.meta
+
+TRANSLATIONS_PATTERN = '{path}.{lang}.{ext}'
+
+# Links for the sidebar / navigation bar.  (translatable)
+# This is a dict.  The keys are languages, and values are tuples.
+#
+# For regular links:
+#     ('https://getnikola.com/', 'Nikola Homepage')
+#
+# For submenus:
+#     (
+#         (
+#             ('https://apple.com/', 'Apple'),
+#             ('https://orange.com/', 'Orange'),
+#         ),
+#         'Fruits'
+#     )
+#
+# WARNING: Support for submenus is theme-dependent.
+#          Only one level of submenus is supported.
+# WARNING: Some themes, including the default Bootstrap 4 theme,
+#          may present issues if the menu is too large.
+#          (in Bootstrap, the navbar can grow too large and cover contents.)
+# WARNING: If you link to directories, make sure to follow
+#          ``STRIP_INDEXES``.  If it’s set to ``True``, end your links
+#          with a ``/``, otherwise end them with ``/index.html`` — or
+#          else they won’t be highlighted when active.
+
+NAVIGATION_LINKS = {
+    DEFAULT_LANG: (
+        ("/", "Home"),
+        ("/documentation/#QuickStart", "Getting Started"),
+        ("/documentation/#Components", "Components"),
+        ("/documentation/#Protocols", "Supported Protocols"),
+        ("/documentation/", "Documentation"),
+        ("/hedgehog/", "Hedgehog Linux"),
+        ("https://github.com/idaholab/Malcolm", "↪ GitHub")
+    ),
+}
+
+# Alternative navigation links. Works the same way NAVIGATION_LINKS does,
+# although themes may not always support them. (translatable)
+# (Bootstrap 4: right-side of navbar, Bootblog 4: right side of title)
+NAVIGATION_ALT_LINKS = {
+    DEFAULT_LANG: ()
+}
+
+# Name of the theme to use.
+THEME = "hyde"
+
+# Primary color of your theme. This will be used to customize your theme.
+# Must be a HEX value.
+THEME_COLOR = '#5670d4'
+
+# POSTS and PAGES contains (wildcard, destination, template) tuples.
+# (translatable)
+#
+# The wildcard is used to generate a list of source files
+# (whatever/thing.rst, for example).
+#
+# That fragment could have an associated metadata file (whatever/thing.meta),
+# and optionally translated files (example for Spanish, with code "es"):
+#     whatever/thing.es.rst and whatever/thing.es.meta
+#
+#     This assumes you use the default TRANSLATIONS_PATTERN.
+#
+# From those files, a set of HTML fragment files will be generated:
+# cache/whatever/thing.html (and maybe cache/whatever/thing.html.es)
+#
+# These files are combined with the template to produce rendered
+# pages, which will be placed at
+# output/TRANSLATIONS[lang]/destination/pagename.html
+#
+# where "pagename" is the "slug" specified in the metadata file.
+# The page might also be placed in /destination/pagename/index.html
+# if PRETTY_URLS are enabled.
+#
+# The difference between POSTS and PAGES is that POSTS are added
+# to feeds, indexes, tag lists and archives and are considered part
+# of a blog, while PAGES are just independent HTML pages.
+#
+# Finally, note that destination can be translated, i.e. you can
+# specify a different translation folder per language. Example:
+#     PAGES = (
+#         ("pages/*.rst", {"en": "pages", "de": "seiten"}, "page.tmpl"),
+#         ("pages/*.md", {"en": "pages", "de": "seiten"}, "page.tmpl"),
+#     )
+
+POSTS = (
+    ("posts/*.rst", "blog", "post.tmpl"),
+    ("posts/*.md", "blog", "post.tmpl"),
+    ("posts/*.txt", "blog", "post.tmpl"),
+    ("posts/*.html", "blog", "post.tmpl"),
+)
+PAGES = (
+    ("pages/*.rst", "", "page.tmpl"),
+    ("pages/*.md", "", "page.tmpl"),
+    ("pages/*.txt", "", "page.tmpl"),
+    ("pages/*.html", "", "page.tmpl"),
+)
+
+
+# Below this point, everything is optional
+
+# Post's dates are considered in UTC by default, if you want to use
+# another time zone, please set TIMEZONE to match. Check the available
+# list from Wikipedia:
+# https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
+# (e.g. 'Europe/Zurich')
+# Also, if you want to use a different time zone in some of your posts,
+# you can use the ISO 8601/RFC 3339 format (ex. 2012-03-30T23:00:00+02:00)
+TIMEZONE = "America/Denver"
+
+# If you want to use ISO 8601 (also valid RFC 3339) throughout Nikola
+# (especially in new_post), set this to True.
+# Note that this does not affect DATE_FORMAT.
+# FORCE_ISO8601 = False
+
+# Date format used to display post dates. (translatable)
+# Used by babel.dates, CLDR style: http://cldr.unicode.org/translation/date-time
+# You can also use 'full', 'long', 'medium', or 'short'
+# DATE_FORMAT = 'YYYY-MM-dd HH:mm'
+
+# Date format used to display post dates, if local dates are used. (translatable)
+# Used by moment.js: https://momentjs.com/docs/#/displaying/format/
+# JS_DATE_FORMAT = 'YYYY-MM-DD HH:mm'
+
+# Date fanciness.
+#
+# 0 = using DATE_FORMAT and TIMEZONE
+# 1 = using JS_DATE_FORMAT and local user time (via moment.js)
+# 2 = using a string like “2 days ago”
+#
+# Your theme must support it, Bootstrap already does.
+# DATE_FANCINESS = 0
+
+# Customize the locale/region used for a language.
+# For example, to use British instead of US English: LOCALES = {'en': 'en_GB'}
+# LOCALES = {}
+
+# One or more folders containing files to be copied as-is into the output.
+# The format is a dictionary of {source: relative destination}.
+# Default is:
+# FILES_FOLDERS = {'files': ''}
+# Which means copy 'files' into 'output'
+
+# One or more folders containing code listings to be processed and published on
+# the site. The format is a dictionary of {source: relative destination}.
+# Default is:
+# LISTINGS_FOLDERS = {'listings': 'listings'}
+# Which means process listings from 'listings' into 'output/listings'
+
+# A mapping of languages to file-extensions that represent that language.
+# Feel free to add or delete extensions to any list, but don't add any new
+# compilers unless you write the interface for it yourself.
+#
+# The default compiler for `new_post` is the first entry in the POSTS tuple.
+#
+# 'rest' is reStructuredText
+# 'markdown' is Markdown
+# 'html' assumes the file is HTML and just copies it
+COMPILERS = {
+    "rest": ('.rst', '.txt'),
+    "markdown": ('.md', '.mdown', '.markdown'),
+    "textile": ('.textile',),
+    "txt2tags": ('.t2t',),
+    "bbcode": ('.bb',),
+    "wiki": ('.wiki',),
+    "ipynb": ('.ipynb',),
+    "html": ('.html', '.htm'),
+    # PHP files are rendered the usual way (i.e. with the full templates).
+    # The resulting files have .php extensions, making it possible to run
+    # them without reconfiguring your server to recognize them.
+    "php": ('.php',),
+    # Pandoc detects the input from the source filename
+    # but is disabled by default as it would conflict
+    # with many of the others.
+    # "pandoc": ('.rst', '.md', '.txt'),
+}
+
+# Enable reST directives that insert the contents of external files such
+# as "include" and "raw." This maps directly to the docutils file_insertion_enabled
+# config. See: http://docutils.sourceforge.net/docs/user/config.html#file-insertion-enabled
+# REST_FILE_INSERTION_ENABLED = True
+
+# Create by default posts in one file format?
+# Set to False for two-file posts, with separate metadata.
+# ONE_FILE_POSTS = True
+
+# Preferred metadata format for new posts
+# "Nikola": reST comments, wrapped in a HTML comment if needed (default)
+# "YAML": YAML wrapped in "---"
+# "TOML": TOML wrapped in "+++"
+# "Pelican": Native markdown metadata or reST docinfo fields. Nikola style for other formats.
+# METADATA_FORMAT = "Nikola"
+
+# Use date-based path when creating posts?
+# Can be enabled on a per-post basis with `nikola new_post -d`.
+# The setting is ignored when creating pages.
+# NEW_POST_DATE_PATH = False
+
+# What format to use when creating posts with date paths?
+# Default is '%Y/%m/%d', other possibilities include '%Y' or '%Y/%m'.
+# NEW_POST_DATE_PATH_FORMAT = '%Y/%m/%d'
+
+# If this is set to True, the DEFAULT_LANG version will be displayed for
+# untranslated posts.
+# If this is set to False, then posts that are not translated to a language
+# LANG will not be visible at all in the pages in that language.
+# SHOW_UNTRANSLATED_POSTS = True
+
+# Nikola supports logo display.  If you have one, you can put the URL here.
+# Final output is <img src="LOGO_URL" id="logo" alt="BLOG_TITLE">.
+# The URL may be relative to the site root.
+LOGO_URL = 'https://raw.githubusercontent.com/idaholab/Malcolm/development/docs/images/logo/Malcolm_reflection_white.png'
+
+# If you want to hide the title of your website (for example, if your logo
+# already contains the text), set this to False.
+SHOW_BLOG_TITLE = False
+
+# Paths for different autogenerated bits. These are combined with the
+# translation paths.
+
+# Final locations are:
+# output / TRANSLATION[lang] / TAG_PATH / index.html (list of tags)
+# output / TRANSLATION[lang] / TAG_PATH / tag.html (list of posts for a tag)
+# output / TRANSLATION[lang] / TAG_PATH / tag RSS_EXTENSION (RSS feed for a tag)
+# (translatable)
+# TAG_PATH = "categories"
+
+# By default, the list of tags is stored in
+#     output / TRANSLATION[lang] / TAG_PATH / index.html
+# (see explanation for TAG_PATH). This location can be changed to
+#     output / TRANSLATION[lang] / TAGS_INDEX_PATH
+# with an arbitrary relative path TAGS_INDEX_PATH.
+# (translatable)
+# TAGS_INDEX_PATH = "tags.html"
+
+# If TAG_PAGES_ARE_INDEXES is set to True, each tag's page will contain
+# the posts themselves. If set to False, it will be just a list of links.
+# TAG_PAGES_ARE_INDEXES = False
+
+# Set descriptions for tag pages to make them more interesting. The
+# default is no description. The value is used in the meta description
+# and displayed underneath the tag list or index page’s title.
+# TAG_DESCRIPTIONS = {
+#    DEFAULT_LANG: {
+#        "blogging": "Meta-blog posts about blogging.",
+#        "open source": "My contributions to my many, varied, ever-changing, and eternal libre software projects."
+#    },
+# }
+
+# Set special titles for tag pages. The default is "Posts about TAG".
+# TAG_TITLES = {
+#    DEFAULT_LANG: {
+#        "blogging": "Meta-posts about blogging",
+#        "open source": "Posts about open source software"
+#    },
+# }
+
+# If you do not want to display a tag publicly, you can mark it as hidden.
+# The tag will not be displayed on the tag list page and posts.
+# Tag pages will still be generated.
+HIDDEN_TAGS = ['mathjax']
+
+# Only include tags on the tag list/overview page if there are at least
+# TAGLIST_MINIMUM_POSTS number of posts or more with every tag. Every tag
+# page is still generated, linked from posts, and included in the sitemap.
+# However, more obscure tags can be hidden from the tag index page.
+# TAGLIST_MINIMUM_POSTS = 1
+
+# A list of dictionaries specifying tags which translate to each other.
+# Format: a list of dicts {language: translation, language2: translation2, …}
+# For example:
+#   [
+#     {'en': 'private', 'de': 'Privat'},
+#     {'en': 'work', 'fr': 'travail', 'de': 'Arbeit'},
+#   ]
+# TAG_TRANSLATIONS = []
+
+# If set to True, a tag in a language will be treated as a translation
+# of the literally same tag in all other languages. Enable this if you
+# do not translate tags, for example.
+# TAG_TRANSLATIONS_ADD_DEFAULTS = True
+
+# Final locations are:
+# output / TRANSLATION[lang] / CATEGORY_PATH / index.html (list of categories)
+# output / TRANSLATION[lang] / CATEGORY_PATH / CATEGORY_PREFIX category.html (list of posts for a category)
+# output / TRANSLATION[lang] / CATEGORY_PATH / CATEGORY_PREFIX category RSS_EXTENSION (RSS feed for a category)
+# (translatable)
+# CATEGORY_PATH = "categories"
+# CATEGORY_PREFIX = "cat_"
+
+# By default, the list of categories is stored in
+#     output / TRANSLATION[lang] / CATEGORY_PATH / index.html
+# (see explanation for CATEGORY_PATH). This location can be changed to
+#     output / TRANSLATION[lang] / CATEGORIES_INDEX_PATH
+# with an arbitrary relative path CATEGORIES_INDEX_PATH.
+# (translatable)
+# CATEGORIES_INDEX_PATH = "categories.html"
+
+# If CATEGORY_ALLOW_HIERARCHIES is set to True, categories can be organized in
+# hierarchies. For a post, the whole path in the hierarchy must be specified,
+# using a forward slash ('/') to separate paths. Use a backslash ('\') to escape
+# a forward slash or a backslash (i.e. '\//\\' is a path specifying the
+# subcategory called '\' of the top-level category called '/').
+CATEGORY_ALLOW_HIERARCHIES = False
+# If CATEGORY_OUTPUT_FLAT_HIERARCHY is set to True, the output written to output
+# contains only the name of the leaf category and not the whole path.
+CATEGORY_OUTPUT_FLAT_HIERARCHY = False
+
+# If CATEGORY_PAGES_ARE_INDEXES is set to True, each category's page will contain
+# the posts themselves. If set to False, it will be just a list of links.
+# CATEGORY_PAGES_ARE_INDEXES = False
+
+# Set descriptions for category pages to make them more interesting. The
+# default is no description. The value is used in the meta description
+# and displayed underneath the category list or index page’s title.
+# CATEGORY_DESCRIPTIONS = {
+#    DEFAULT_LANG: {
+#        "blogging": "Meta-blog posts about blogging.",
+#        "open source": "My contributions to my many, varied, ever-changing, and eternal libre software projects."
+#    },
+# }
+
+# Set special titles for category pages. The default is "Posts about CATEGORY".
+# CATEGORY_TITLES = {
+#    DEFAULT_LANG: {
+#        "blogging": "Meta-posts about blogging",
+#        "open source": "Posts about open source software"
+#    },
+# }
+
+# If you do not want to display a category publicly, you can mark it as hidden.
+# The category will not be displayed on the category list page.
+# Category pages will still be generated.
+HIDDEN_CATEGORIES = []
+
+# A list of dictionaries specifying categories which translate to each other.
+# Format: a list of dicts {language: translation, language2: translation2, …}
+# See TAG_TRANSLATIONS example above.
+# CATEGORY_TRANSLATIONS = []
+
+# If set to True, a category in a language will be treated as a translation
+# of the literally same category in all other languages. Enable this if you
+# do not translate categories, for example.
+# CATEGORY_TRANSLATIONS_ADD_DEFAULTS = True
+
+# If no category is specified in a post, the destination path of the post
+# can be used in its place. This replaces the sections feature. Using
+# category hierarchies is recommended.
+# CATEGORY_DESTPATH_AS_DEFAULT = False
+
+# If True, the prefix will be trimmed from the category name, eg. if the
+# POSTS destination is "foo/bar", and the path is "foo/bar/baz/quux",
+# the category will be "baz/quux" (or "baz" if only the first directory is considered).
+# Note that prefixes coming from translations are always ignored.
+# CATEGORY_DESTPATH_TRIM_PREFIX = False
+
+# If True, only the first directory of a path will be used.
+# CATEGORY_DESTPATH_FIRST_DIRECTORY_ONLY = True
+
+# Map paths to prettier category names. (translatable)
+# CATEGORY_DESTPATH_NAMES = {
+#    DEFAULT_LANG: {
+#        'webdev': 'Web Development',
+#        'webdev/django': 'Web Development/Django',
+#        'random': 'Odds and Ends',
+#    },
+# }
+
+# By default, category indexes will appear in CATEGORY_PATH and use
+# CATEGORY_PREFIX. If this is enabled, those settings will be ignored (except
+# for the index) and instead, they will follow destination paths (eg. category
+# 'foo' might appear in 'posts/foo'). If the category does not come from a
+# destpath, first entry in POSTS followed by the category name will be used.
+# For this setting, category hierarchies are required and cannot be flattened.
+# CATEGORY_PAGES_FOLLOW_DESTPATH = False
+
+# If ENABLE_AUTHOR_PAGES is set to True and there is more than one
+# author, author pages are generated.
+# ENABLE_AUTHOR_PAGES = True
+
+# Path to author pages. Final locations are:
+# output / TRANSLATION[lang] / AUTHOR_PATH / index.html (list of authors)
+# output / TRANSLATION[lang] / AUTHOR_PATH / author.html (list of posts by an author)
+# output / TRANSLATION[lang] / AUTHOR_PATH / author RSS_EXTENSION (RSS feed for an author)
+# (translatable)
+# AUTHOR_PATH = "authors"
+
+# If AUTHOR_PAGES_ARE_INDEXES is set to True, each author's page will contain
+# the posts themselves. If set to False, it will be just a list of links.
+# AUTHOR_PAGES_ARE_INDEXES = False
+
+# Set descriptions for author pages to make them more interesting. The
+# default is no description. The value is used in the meta description
+# and displayed underneath the author list or index page’s title.
+# AUTHOR_PAGES_DESCRIPTIONS = {
+#    DEFAULT_LANG: {
+#        "Juanjo Conti": "Python coder and writer.",
+#        "Roberto Alsina": "Nikola father."
+#    },
+# }
+
+
+# If you do not want to display an author publicly, you can mark it as hidden.
+# The author will not be displayed on the author list page and posts.
+# Tag pages will still be generated.
+HIDDEN_AUTHORS = ['Guest']
+
+# Final location for the main blog page and sibling paginated pages is
+# output / TRANSLATION[lang] / INDEX_PATH / index-*.html
+# (translatable)
+INDEX_PATH = "blog"
+
+# Optional HTML that displayed on “main” blog index.html files.
+# May be used for a greeting. (translatable)
+FRONT_INDEX_HEADER = {
+    DEFAULT_LANG: ''
+}
+
+# Create per-month archives instead of per-year
+# CREATE_MONTHLY_ARCHIVE = False
+# Create one large archive instead of per-year
+# CREATE_SINGLE_ARCHIVE = False
+# Create year, month, and day archives each with a (long) list of posts
+# (overrides both CREATE_MONTHLY_ARCHIVE and CREATE_SINGLE_ARCHIVE)
+# CREATE_FULL_ARCHIVES = False
+# If monthly archives or full archives are created, adds also one archive per day
+# CREATE_DAILY_ARCHIVE = False
+# Create previous, up, next navigation links for archives
+# CREATE_ARCHIVE_NAVIGATION = False
+# Final locations for the archives are:
+# output / TRANSLATION[lang] / ARCHIVE_PATH / ARCHIVE_FILENAME
+# output / TRANSLATION[lang] / ARCHIVE_PATH / YEAR / index.html
+# output / TRANSLATION[lang] / ARCHIVE_PATH / YEAR / MONTH / index.html
+# output / TRANSLATION[lang] / ARCHIVE_PATH / YEAR / MONTH / DAY / index.html
+# (translatable)
+# ARCHIVE_PATH = ""
+# ARCHIVE_FILENAME = "archive.html"
+
+# If ARCHIVES_ARE_INDEXES is set to True, each archive page which contains a list
+# of posts will contain the posts themselves. If set to False, it will be just a
+# list of links.
+# ARCHIVES_ARE_INDEXES = False
+
+# URLs to other posts/pages can take 3 forms:
+# rel_path: a relative URL to the current page/post (default)
+# full_path: a URL with the full path from the root
+# absolute: a complete URL (that includes the SITE_URL)
+# URL_TYPE = 'rel_path'
+
+# Extension for RSS feed files
+# RSS_EXTENSION = ".xml"
+
+# RSS filename base (without extension); used for indexes and galleries.
+# (translatable)
+# RSS_FILENAME_BASE = "rss"
+
+# Final location for the blog main RSS feed is:
+# output / TRANSLATION[lang] / RSS_PATH / RSS_FILENAME_BASE RSS_EXTENSION
+# (translatable)
+# RSS_PATH = ""
+
+# Final location for the blog main Atom feed is:
+# output / TRANSLATION[lang] / ATOM_PATH / ATOM_FILENAME_BASE ATOM_EXTENSION
+# (translatable)
+# ATOM_PATH = ""
+
+# Atom filename base (without extension); used for indexes.
+# (translatable)
+ATOM_FILENAME_BASE = "feed"
+
+# Extension for Atom feed files
+# ATOM_EXTENSION = ".atom"
+
+# Slug the Tag URL. Easier for users to type, special characters are
+# often removed or replaced as well.
+# SLUG_TAG_PATH = True
+
+# Slug the Author URL. Easier for users to type, special characters are
+# often removed or replaced as well.
+# SLUG_AUTHOR_PATH = True
+
+# A list of redirection tuples, [("foo/from.html", "/bar/to.html")].
+#
+# A HTML file will be created in output/foo/from.html that redirects
+# to the "/bar/to.html" URL. notice that the "from" side MUST be a
+# relative URL.
+#
+# If you don't need any of these, just set to []
+REDIRECTIONS = []
+
+# Presets of commands to execute to deploy. Can be anything, for
+# example, you may use rsync:
+# "rsync -rav --delete output/ joe@my.site:/srv/www/site"
+# And then do a backup, or run `nikola ping` from the `ping`
+# plugin (`nikola plugin -i ping`).  Or run `nikola check -l`.
+# You may also want to use github_deploy (see below).
+# You can define multiple presets and specify them as arguments
+# to `nikola deploy`.  If no arguments are specified, a preset
+# named `default` will be executed.  You can use as many presets
+# in a `nikola deploy` command as you like.
+# DEPLOY_COMMANDS = {
+#     'default': [
+#         "rsync -rav --delete output/ joe@my.site:/srv/www/site",
+#     ]
+# }
+
+# github_deploy configuration
+# For more details, read the manual:
+# https://getnikola.com/handbook.html#deploying-to-github
+# You will need to configure the deployment branch on GitHub.
+GITHUB_SOURCE_BRANCH = 'src'
+GITHUB_DEPLOY_BRANCH = 'master'
+
+# The name of the remote where you wish to push to, using github_deploy.
+GITHUB_REMOTE_NAME = 'origin'
+
+# Whether or not github_deploy should commit to the source branch automatically
+# before deploying.
+GITHUB_COMMIT_SOURCE = True
+
+# Where the output site should be located
+# If you don't use an absolute path, it will be considered as relative
+# to the location of conf.py
+# OUTPUT_FOLDER = 'output'
+
+# where the "cache" of partial generated content should be located
+# default: 'cache'
+# CACHE_FOLDER = 'cache'
+
+# Filters to apply to the output.
+# A directory where the keys are either: a file extensions, or
+# a tuple of file extensions.
+#
+# And the value is a list of commands to be applied in order.
+#
+# Each command must be either:
+#
+# A string containing a '%s' which will
+# be replaced with a filename. The command *must* produce output
+# in place.
+#
+# Or:
+#
+# A python callable, which will be called with the filename as
+# argument.
+#
+# By default, only .php files uses filters to inject PHP into
+# Nikola’s templates. All other filters must be enabled through FILTERS.
+#
+# Many filters are shipped with Nikola. A list is available in the manual:
+# <https://getnikola.com/handbook.html#post-processing-filters>
+#
+# from nikola import filters
+# FILTERS = {
+#    ".html": [filters.typogrify],
+#    ".js": [filters.closure_compiler],
+#    ".jpg": ["jpegoptim --strip-all -m75 -v %s"],
+# }
+
+# Executable for the "yui_compressor" filter (defaults to 'yui-compressor').
+# YUI_COMPRESSOR_EXECUTABLE = 'yui-compressor'
+
+# Executable for the "closure_compiler" filter (defaults to 'closure-compiler').
+# CLOSURE_COMPILER_EXECUTABLE = 'closure-compiler'
+
+# Executable for the "optipng" filter (defaults to 'optipng').
+# OPTIPNG_EXECUTABLE = 'optipng'
+
+# Executable for the "jpegoptim" filter (defaults to 'jpegoptim').
+# JPEGOPTIM_EXECUTABLE = 'jpegoptim'
+
+# Executable for the "html_tidy_withconfig", "html_tidy_nowrap",
+# "html_tidy_wrap", "html_tidy_wrap_attr" and "html_tidy_mini" filters
+# (defaults to 'tidy5').
+# HTML_TIDY_EXECUTABLE = 'tidy5'
+
+# List of XPath expressions which should be used for finding headers
+# ({hx} is replaced by headers h1 through h6).
+# You must change this if you use a custom theme that does not use
+# "e-content entry-content" as a class for post and page contents.
+# HEADER_PERMALINKS_XPATH_LIST = ['*//div[@class="e-content entry-content"]//{hx}']
+# Include *every* header (not recommended):
+# HEADER_PERMALINKS_XPATH_LIST = ['*//{hx}']
+
+# File blacklist for header permalinks. Contains output path
+# (eg. 'output/index.html')
+# HEADER_PERMALINKS_FILE_BLACKLIST = []
+
+# Expert setting! Create a gzipped copy of each generated file. Cheap server-
+# side optimization for very high traffic sites or low memory servers.
+# GZIP_FILES = False
+# File extensions that will be compressed
+# GZIP_EXTENSIONS = ('.txt', '.htm', '.html', '.css', '.js', '.json', '.atom', '.xml')
+# Use an external gzip command? None means no.
+# Example: GZIP_COMMAND = "pigz -k {filename}"
+# GZIP_COMMAND = None
+# Make sure the server does not return a "Accept-Ranges: bytes" header for
+# files compressed by this option! OR make sure that a ranged request does not
+# return partial content of another representation for these resources. Do not
+# use this feature if you do not understand what this means.
+
+# #############################################################################
+# Image Gallery Options
+# #############################################################################
+
+# One or more folders containing galleries. The format is a dictionary of
+# {"source": "relative_destination"}, where galleries are looked for in
+# "source/" and the results will be located in
+# "OUTPUT_PATH/relative_destination/gallery_name"
+# Default is:
+# GALLERY_FOLDERS = {"galleries": "galleries"}
+# More gallery options:
+# THUMBNAIL_SIZE = 180
+# MAX_IMAGE_SIZE = 1280
+# USE_FILENAME_AS_TITLE = True
+# EXTRA_IMAGE_EXTENSIONS = []
+#
+# If set to False, it will sort by filename instead. Defaults to True
+# GALLERY_SORT_BY_DATE = True
+
+# If set to True, EXIF data will be copied when an image is thumbnailed or
+# resized. (See also EXIF_WHITELIST)
+# PRESERVE_EXIF_DATA = False
+
+# If you have enabled PRESERVE_EXIF_DATA, this option lets you choose EXIF
+# fields you want to keep in images. (See also PRESERVE_EXIF_DATA)
+#
+# For a full list of field names, please see here:
+# http://www.cipa.jp/std/documents/e/DC-008-2012_E.pdf
+#
+# This is a dictionary of lists. Each key in the dictionary is the
+# name of a IDF, and each list item is a field you want to preserve.
+# If you have a IDF with only a '*' item, *EVERY* item in it will be
+# preserved. If you don't want to preserve anything in a IDF, remove it
+# from the setting. By default, no EXIF information is kept.
+# Setting the whitelist to anything other than {} implies
+# PRESERVE_EXIF_DATA is set to True
+# To preserve ALL EXIF data, set EXIF_WHITELIST to {"*": "*"}
+
+# EXIF_WHITELIST = {}
+
+# Some examples of EXIF_WHITELIST settings:
+
+# Basic image information:
+# EXIF_WHITELIST['0th'] = [
+#    "Orientation",
+#    "XResolution",
+#    "YResolution",
+# ]
+
+# If you want to keep GPS data in the images:
+# EXIF_WHITELIST['GPS'] = ["*"]
+
+# Embedded thumbnail information:
+# EXIF_WHITELIST['1st'] = ["*"]
+
+# If set to True, any ICC profile will be copied when an image is thumbnailed or
+# resized.
+# PRESERVE_ICC_PROFILES = False
+
+# Folders containing images to be used in normal posts or pages.
+# IMAGE_FOLDERS is a dictionary of the form {"source": "destination"},
+# where "source" is the folder containing the images to be published, and
+# "destination" is the folder under OUTPUT_PATH containing the images copied
+# to the site. Thumbnail images will be created there as well.
+
+# To reference the images in your posts, include a leading slash in the path.
+# For example, if IMAGE_FOLDERS = {'images': 'images'}, write
+#
+#   .. image:: /images/tesla.jpg
+#
+# See the Nikola Handbook for details (in the “Embedding Images” and
+# “Thumbnails” sections)
+
+# Images will be scaled down according to IMAGE_THUMBNAIL_SIZE and MAX_IMAGE_SIZE
+# options, but will have to be referenced manually to be visible on the site
+# (the thumbnail has ``.thumbnail`` added before the file extension by default,
+# but a different naming template can be configured with IMAGE_THUMBNAIL_FORMAT).
+
+IMAGE_FOLDERS = {'images': 'images'}
+# IMAGE_THUMBNAIL_SIZE = 400
+# IMAGE_THUMBNAIL_FORMAT = '{name}.thumbnail{ext}'
+
+# #############################################################################
+# HTML fragments and diverse things that are used by the templates
+# #############################################################################
+
+# Data about post-per-page indexes.
+# INDEXES_PAGES defaults to ' old posts, page %d' or ' page %d' (translated),
+# depending on the value of INDEXES_PAGES_MAIN.
+#
+# (translatable) If the following is empty, defaults to BLOG_TITLE:
+# INDEXES_TITLE = ""
+#
+# (translatable) If the following is empty, defaults to ' [old posts,] page %d' (see above):
+# INDEXES_PAGES = ""
+#
+# If the following is True, INDEXES_PAGES is also displayed on the main (the
+# newest) index page (index.html):
+# INDEXES_PAGES_MAIN = False
+#
+# If the following is True, index-1.html has the oldest posts, index-2.html the
+# second-oldest posts, etc., and index.html has the newest posts. This ensures
+# that all posts on index-x.html will forever stay on that page, now matter how
+# many new posts are added.
+# If False, index-1.html has the second-newest posts, index-2.html the third-newest,
+# and index-n.html the oldest posts. When this is active, old posts can be moved
+# to other index pages when new posts are added.
+# INDEXES_STATIC = True
+#
+# (translatable) If PRETTY_URLS is set to True, this setting will be used to create
+# prettier URLs for index pages, such as page/2/index.html instead of index-2.html.
+# Valid values for this settings are:
+#   * False,
+#   * a list or tuple, specifying the path to be generated,
+#   * a dictionary mapping languages to lists or tuples.
+# Every list or tuple must consist of strings which are used to combine the path;
+# for example:
+#     ['page', '{number}', '{index_file}']
+# The replacements
+#     {number}     --> (logical) page number;
+#     {old_number} --> the page number inserted into index-n.html before (zero for
+#                      the main page);
+#     {index_file} --> value of option INDEX_FILE
+# are made.
+# Note that in case INDEXES_PAGES_MAIN is set to True, a redirection will be created
+# for the full URL with the page number of the main page to the normal (shorter) main
+# page URL.
+# INDEXES_PRETTY_PAGE_URL = False
+#
+# If the following is true, a page range navigation will be inserted to indices.
+# Please note that this will undo the effect of INDEXES_STATIC, as all index pages
+# must be recreated whenever the number of pages changes.
+# SHOW_INDEX_PAGE_NAVIGATION = False
+
+# If the following is True, a meta name="generator" tag is added to pages. The
+# generator tag is used to specify the software used to generate the page
+# (it promotes Nikola).
+# META_GENERATOR_TAG = True
+
+# Color scheme to be used for code blocks. If your theme provides
+# "assets/css/code.css" this is ignored. Set to None to disable.
+# Can be any of:
+# algol, algol_nu, autumn, borland, bw, colorful, default, emacs, friendly,
+# fruity, igor, lovelace, manni, monokai, murphy, native, paraiso-dark,
+# paraiso-light, pastie, perldoc, rrt, tango, trac, vim, vs, xcode
+# This list MAY be incomplete since pygments adds styles every now and then.
+# Check with list(pygments.styles.get_all_styles()) in an interpreter.
+#
+# CODE_COLOR_SCHEME = 'default'
+
+# FAVICONS contains (name, file, size) tuples.
+# Used to create favicon link like this:
+# <link rel="name" href="file" sizes="size"/>
+# FAVICONS = (
+#     ("icon", "/favicon.ico", "16x16"),
+#     ("icon", "/icon_128x128.png", "128x128"),
+# )
+
+# Show teasers (instead of full posts) in indexes? Defaults to False.
+# INDEX_TEASERS = False
+
+# HTML fragments with the Read more... links.
+# The following tags exist and are replaced for you:
+# {link}                        A link to the full post page.
+# {read_more}                   The string “Read more” in the current language.
+# {reading_time}                An estimate of how long it will take to read the post.
+# {remaining_reading_time}      An estimate of how long it will take to read the post, sans the teaser.
+# {min_remaining_read}          The string “{remaining_reading_time} min remaining to read” in the current language.
+# {paragraph_count}             The amount of paragraphs in the post.
+# {remaining_paragraph_count}   The amount of paragraphs in the post, sans the teaser.
+# {post_title}                  The title of the post.
+# {{                            A literal { (U+007B LEFT CURLY BRACKET)
+# }}                            A literal } (U+007D RIGHT CURLY BRACKET)
+
+# 'Read more...' for the index page, if INDEX_TEASERS is True (translatable)
+INDEX_READ_MORE_LINK = '<p class="more"><a href="{link}">{read_more}…</a></p>'
+# 'Read more...' for the feeds, if FEED_TEASERS is True (translatable)
+FEED_READ_MORE_LINK = '<p><a href="{link}">{read_more}…</a> ({min_remaining_read})</p>'
+
+# Append a URL query to the FEED_READ_MORE_LINK in Atom and RSS feeds. Advanced
+# option used for traffic source tracking.
+# Minimum example for use with Piwik: "pk_campaign=feed"
+# The following tags exist and are replaced for you:
+# {feedRelUri}                  A relative link to the feed.
+# {feedFormat}                  The name of the syndication format.
+# Example using replacement for use with Google Analytics:
+# "utm_source={feedRelUri}&utm_medium=nikola_feed&utm_campaign={feedFormat}_feed"
+FEED_LINKS_APPEND_QUERY = False
+
+# A HTML fragment describing the license, for the sidebar.
+# (translatable)
+LICENSE = LICENSE = """
+<a rel="license" href="https://raw.githubusercontent.com/idaholab/Malcolm/master/License.txt">License</a>"""
+# I recommend using the Creative Commons' wizard:
+# https://creativecommons.org/choose/
+# LICENSE = """
+# <a rel="license" href="https://creativecommons.org/licenses/by-nc-sa/4.0/">
+# <img alt="Creative Commons License BY-NC-SA"
+# style="border-width:0; margin-bottom:12px;"
+# src="https://i.creativecommons.org/l/by-nc-sa/4.0/88x31.png"></a>"""
+
+# A small copyright notice for the page footer (in HTML).
+# (translatable)
+CONTENT_FOOTER = 'This site mirrors the documentation of <a href="https://github.com/idaholab/Malcolm">Malcolm</a>, an open-source project developed at <a href="https://github.com/idaholab/">INL</a> and funded by <a href="https://www.dhs.gov/">DHS</a>. This site is not operated by INL nor DHS: its content is the sole responsibility of <a href="mailto:{email}">its maintainer</a>. See {license} for Malcolm\'s license terms.'
+
+# Things that will be passed to CONTENT_FOOTER.format().  This is done
+# for translatability, as dicts are not formattable.  Nikola will
+# intelligently format the setting properly.
+# The setting takes a dict. The keys are languages. The values are
+# tuples of tuples of positional arguments and dicts of keyword arguments
+# to format().  For example, {'en': (('Hello'), {'target': 'World'})}
+# results in CONTENT_FOOTER['en'].format('Hello', target='World').
+# If you need to use the literal braces '{' and '}' in your footer text, use
+# '{{' and '}}' to escape them (str.format is used)
+# WARNING: If you do not use multiple languages with CONTENT_FOOTER, this
+#          still needs to be a dict of this format.  (it can be empty if you
+#          do not need formatting)
+# (translatable)
+CONTENT_FOOTER_FORMATS = {
+    DEFAULT_LANG: (
+        (),
+        {
+            "email": BLOG_EMAIL,
+            "author": BLOG_AUTHOR,
+            "date": time.gmtime().tm_year,
+            "license": LICENSE,
+            "siteurl": SITE_URL
+        }
+    )
+}
+
+# A simple copyright tag for inclusion in RSS feeds that works just
+# like CONTENT_FOOTER and CONTENT_FOOTER_FORMATS
+RSS_COPYRIGHT = 'Contents © {date} <a href="mailto:{email}">{author}</a> {license}'
+RSS_COPYRIGHT_PLAIN = 'Contents © {date} {author} {license}'
+RSS_COPYRIGHT_FORMATS = CONTENT_FOOTER_FORMATS
+
+# To use comments, you can choose between different third party comment
+# systems.  The following comment systems are supported by Nikola:
+#   disqus, facebook, intensedebate, isso, muut, commento
+# You can leave this option blank to disable comments.
+COMMENT_SYSTEM = ""
+# And you also need to add your COMMENT_SYSTEM_ID which
+# depends on what comment system you use. The default is
+# "nikolademo" which is a test account for Disqus. More information
+# is in the manual.
+COMMENT_SYSTEM_ID = ""
+
+# Create index.html for page folders?
+# WARNING: if a page would conflict with the index file (usually
+#          caused by setting slug to `index`), the PAGE_INDEX
+#          will not be generated for that directory.
+# PAGE_INDEX = False
+# Enable comments on pages (i.e. not posts)?
+# COMMENTS_IN_PAGES = False
+# Enable comments on picture gallery pages?
+# COMMENTS_IN_GALLERIES = False
+
+# What file should be used for directory indexes?
+# Defaults to index.html
+# Common other alternatives: default.html for IIS, index.php
+# INDEX_FILE = "index.html"
+
+# If a link ends in /index.html,  drop the index.html part.
+# http://mysite/foo/bar/index.html => http://mysite/foo/bar/
+# (Uses the INDEX_FILE setting, so if that is, say, default.html,
+# it will instead /foo/default.html => /foo)
+STRIP_INDEXES = True
+
+# List of files relative to the server root (!) that will be asked to be excluded
+# from indexing and other robotic spidering. * is supported. Will only be effective
+# if SITE_URL points to server root. The list is used to exclude resources from
+# /robots.txt and /sitemap.xml, and to inform search engines about /sitemapindex.xml.
+# ROBOTS_EXCLUSIONS = ["/archive.html", "/category/*.html"]
+
+# Instead of putting files in <slug>.html, put them in <slug>/index.html.
+# No web server configuration is required. Also enables STRIP_INDEXES.
+# This can be disabled on a per-page/post basis by adding
+#    .. pretty_url: False
+# to the metadata.
+PRETTY_URLS = True
+
+# If True, publish future dated posts right away instead of scheduling them.
+# Defaults to False.
+# FUTURE_IS_NOW = False
+
+# If True, future dated posts are allowed in deployed output
+# Only the individual posts are published/deployed; not in indexes/sitemap
+# Generally, you want FUTURE_IS_NOW and DEPLOY_FUTURE to be the same value.
+# DEPLOY_FUTURE = False
+# If False, draft posts will not be deployed
+# DEPLOY_DRAFTS = True
+
+# Allows scheduling of posts using the rule specified here (new_post -s)
+# Specify an iCal Recurrence Rule: http://www.kanzaki.com/docs/ical/rrule.html
+# SCHEDULE_RULE = ''
+# If True, use the scheduling rule to all posts (not pages!) by default
+# SCHEDULE_ALL = False
+
+# Do you want a add a Mathjax config file?
+# MATHJAX_CONFIG = ""
+
+# If you want support for the $.$ syntax (which may conflict with running
+# text!), just use this config:
+# MATHJAX_CONFIG = """
+# <script type="text/x-mathjax-config">
+# MathJax.Hub.Config({
+#     tex2jax: {
+#         inlineMath: [ ['$','$'], ["\\\(","\\\)"] ],
+#         displayMath: [ ['$$','$$'], ["\\\[","\\\]"] ],
+#         processEscapes: true
+#     },
+#     displayAlign: 'center', // Change this to 'left' if you want left-aligned equations.
+#     "HTML-CSS": {
+#         styles: {'.MathJax_Display': {"margin": 0}}
+#     }
+# });
+# </script>
+# """
+
+# Want to use KaTeX instead of MathJax? While KaTeX may not support every
+# feature yet, it's faster and the output looks better.
+# USE_KATEX = False
+
+# KaTeX auto-render settings. If you want support for the $.$ syntax (which may
+# conflict with running text!), just use this config:
+# KATEX_AUTO_RENDER = """
+# delimiters: [
+#     {left: "$$", right: "$$", display: true},
+#     {left: "\\\\[", right: "\\\\]", display: true},
+#     {left: "\\\\begin{equation*}", right: "\\\\end{equation*}", display: true},
+#     {left: "$", right: "$", display: false},
+#     {left: "\\\\(", right: "\\\\)", display: false}
+# ]
+# """
+
+# Do you want to customize the nbconversion of your IPython notebook?
+# IPYNB_CONFIG = {}
+# With the following example configuration you can use a custom jinja template
+# called `toggle.tpl` which has to be located in your site/blog main folder:
+# IPYNB_CONFIG = {'Exporter': {'template_file': 'toggle'}}
+
+# What Markdown extensions to enable?
+# You will also get gist, nikola and podcast because those are
+# done in the code, hope you don't mind ;-)
+# Note: most Nikola-specific extensions are done via the Nikola plugin system,
+#       with the MarkdownExtension class and should not be added here.
+# Defaults are markdown.extensions.(fenced_code|codehilite|extra)
+# markdown.extensions.meta is required for Markdown metadata.
+MARKDOWN_EXTENSIONS = ['markdown.extensions.fenced_code', 'markdown.extensions.codehilite', 'markdown.extensions.extra']
+
+# Options to be passed to markdown extensions (See https://python-markdown.github.io/reference/)
+# Default is {} (no config at all)
+# MARKDOWN_EXTENSION_CONFIGS = {}
+
+
+# Extra options to pass to the pandoc command.
+# by default, it's empty, is a list of strings, for example
+# ['-F', 'pandoc-citeproc', '--bibliography=/Users/foo/references.bib']
+# Pandoc does not demote headers by default.  To enable this, you can use, for example
+# ['--base-header-level=2']
+# PANDOC_OPTIONS = []
+
+# Social buttons. This is sample code for AddThis (which was the default for a
+# long time). Insert anything you want here, or even make it empty (which is
+# the default right now)
+# (translatable)
+# SOCIAL_BUTTONS_CODE = """
+# <!-- Social buttons -->
+# <div id="addthisbox" class="addthis_toolbox addthis_peekaboo_style addthis_default_style addthis_label_style addthis_32x32_style">
+# <a class="addthis_button_more">Share</a>
+# <ul><li><a class="addthis_button_facebook"></a>
+# <li><a class="addthis_button_google_plusone_share"></a>
+# <li><a class="addthis_button_linkedin"></a>
+# <li><a class="addthis_button_twitter"></a>
+# </ul>
+# </div>
+# <script src="https://s7.addthis.com/js/300/addthis_widget.js#pubid=ra-4f7088a56bb93798"></script>
+# <!-- End of social buttons -->
+# """
+
+# Show link to source for the posts?
+# SHOW_SOURCELINK = True
+# Copy the source files for your pages?
+# Setting it to False implies SHOW_SOURCELINK = False
+# COPY_SOURCES = True
+
+# Modify the number of Post per Index Page
+# Defaults to 10
+# INDEX_DISPLAY_POST_COUNT = 10
+
+# By default, Nikola generates RSS files for the website and for tags, and
+# links to it.  Set this to False to disable everything RSS-related.
+# GENERATE_RSS = True
+
+# By default, Nikola does not generates Atom files for indexes and links to
+# them. Generate Atom for tags by setting TAG_PAGES_ARE_INDEXES to True.
+# Atom feeds are built based on INDEX_DISPLAY_POST_COUNT and not FEED_LENGTH
+# Switch between plain-text summaries and full HTML content using the
+# FEED_TEASER option. FEED_LINKS_APPEND_QUERY is also respected. Atom feeds
+# are generated even for old indexes and have pagination link relations
+# between each other. Old Atom feeds with no changes are marked as archived.
+# GENERATE_ATOM = False
+
+# Only include teasers in Atom and RSS feeds. Disabling include the full
+# content. Defaults to True.
+# FEED_TEASERS = True
+
+# Strip HTML from Atom and RSS feed summaries and content. Defaults to False.
+# FEED_PLAIN = False
+
+# Number of posts in Atom and RSS feeds.
+# FEED_LENGTH = 10
+
+# RSS_LINK is a HTML fragment to link the RSS or Atom feeds. If set to None,
+# the base.tmpl will use the feed Nikola generates. However, you may want to
+# change it for a FeedBurner feed or something else.
+# RSS_LINK = None
+
+# A search form to search this site, for the sidebar. You can use a Google
+# custom search (https://www.google.com/cse/)
+# Or a DuckDuckGo search: https://duckduckgo.com/search_box.html
+# Default is no search form.
+# (translatable)
+# SEARCH_FORM = ""
+#
+# This search form works for any site and looks good in the "site" theme where
+# it appears on the navigation bar:
+#
+# SEARCH_FORM = """
+# <!-- DuckDuckGo custom search -->
+# <form method="get" id="search" action="https://duckduckgo.com/"
+#  class="navbar-form pull-left">
+# <input type="hidden" name="sites" value="%s">
+# <input type="hidden" name="k8" value="#444444">
+# <input type="hidden" name="k9" value="#D51920">
+# <input type="hidden" name="kt" value="h">
+# <input type="text" name="q" maxlength="255"
+#  placeholder="Search&hellip;" class="span2" style="margin-top: 4px;">
+# <input type="submit" value="DuckDuckGo Search" style="visibility: hidden;">
+# </form>
+# <!-- End of custom search -->
+# """ % SITE_URL
+#
+# If you prefer a Google search form, here's an example that should just work:
+# SEARCH_FORM = """
+# <!-- Google custom search -->
+# <form method="get" action="https://www.google.com/search" class="navbar-form navbar-right" role="search">
+# <div class="form-group">
+# <input type="text" name="q" class="form-control" placeholder="Search">
+# </div>
+# <button type="submit" class="btn btn-primary">
+# 	<span class="glyphicon glyphicon-search"></span>
+# </button>
+# <input type="hidden" name="sitesearch" value="%s">
+# </form>
+# <!-- End of custom search -->
+# """ % SITE_URL
+
+# Use content distribution networks for jQuery, twitter-bootstrap css and js,
+# and html5shiv (for older versions of Internet Explorer)
+# If this is True, jQuery and html5shiv are served from the Google CDN and
+# Bootstrap is served from BootstrapCDN (provided by MaxCDN)
+# Set this to False if you want to host your site without requiring access to
+# external resources.
+# USE_CDN = False
+
+# Check for USE_CDN compatibility.
+# If you are using custom themes, have configured the CSS properly and are
+# receiving warnings about incompatibility but believe they are incorrect, you
+# can set this to False.
+# USE_CDN_WARNING = True
+
+# Extra things you want in the pages HEAD tag. This will be added right
+# before </head>
+# (translatable)
+# EXTRA_HEAD_DATA = ""
+# Google Analytics or whatever else you use. Added to the bottom of <body>
+# in the default template (base.tmpl).
+# (translatable)
+# BODY_END = ""
+
+# The possibility to extract metadata from the filename by using a
+# regular expression.
+# To make it work you need to name parts of your regular expression.
+# The following names will be used to extract metadata:
+# - title
+# - slug
+# - date
+# - tags
+# - link
+# - description
+#
+# An example re is the following:
+# '.*\/(?P<date>\d{4}-\d{2}-\d{2})-(?P<slug>.*)-(?P<title>.*)\.rst'
+# (Note the '.*\/' in the beginning -- matches source paths relative to conf.py)
+# FILE_METADATA_REGEXP = None
+
+# Should titles fetched from file metadata be unslugified (made prettier?)
+# FILE_METADATA_UNSLUGIFY_TITLES = True
+
+# If enabled, extract metadata from docinfo fields in reST documents.
+# If your text files start with a level 1 heading, it will be treated as the
+# document title and will be removed from the text.
+# USE_REST_DOCINFO_METADATA = False
+
+# If enabled, hide docinfo fields in reST document output
+# HIDE_REST_DOCINFO = False
+
+# Map metadata from other formats to Nikola names.
+# Supported formats: yaml, toml, rest_docinfo, markdown_metadata
+# METADATA_MAPPING = {}
+#
+# Example for Pelican compatibility:
+# METADATA_MAPPING = {
+#     "rest_docinfo": {"summary": "description", "modified": "updated"},
+#     "markdown_metadata": {"summary": "description", "modified": "updated"}
+# }
+# Other examples: https://getnikola.com/handbook.html#mapping-metadata-from-other-formats
+
+# Map metadata between types/values. (Runs after METADATA_MAPPING.)
+# Supported formats: nikola, yaml, toml, rest_docinfo, markdown_metadata
+# The value on the right should be a dict of callables.
+# METADATA_VALUE_MAPPING = {}
+# Examples:
+# METADATA_VALUE_MAPPING = {
+#     "yaml": {"keywords": lambda value: ', '.join(value)},  # yaml: 'keywords' list -> str
+#     "nikola": {
+#         "widgets": lambda value: value.split(', '),  # nikola: 'widgets' comma-separated string -> list
+#         "tags": str.lower  # nikola: force lowercase 'tags' (input would be string)
+#      }
+# }
+
+# Additional metadata that is added to a post when creating a new_post
+# ADDITIONAL_METADATA = {}
+
+# Nikola supports Twitter Card summaries, but they are disabled by default.
+# They make it possible for you to attach media to Tweets that link
+# to your content.
+#
+# Uncomment and modify to following lines to match your accounts.
+# Images displayed come from the `previewimage` meta tag.
+# You can specify the card type by using the `card` parameter in TWITTER_CARD.
+# TWITTER_CARD = {
+#     # 'use_twitter_cards': True,  # enable Twitter Cards
+#     # 'card': 'summary',          # Card type, you can also use 'summary_large_image',
+#                                   # see https://dev.twitter.com/cards/types
+#     # 'site': '@website',         # twitter nick for the website
+#     # 'creator': '@username',     # Username for the content creator / author.
+# }
+
+# Bundle JS and CSS into single files to make site loading faster in a HTTP/1.1
+# environment but is not recommended for HTTP/2.0 when caching is used.
+# Defaults to True.
+# USE_BUNDLES = True
+
+# Plugins you don't want to use. Be careful :-)
+# DISABLED_PLUGINS = ["render_galleries"]
+
+# Special settings to disable only parts of the indexes plugin.
+# Use with care.
+# DISABLE_INDEXES = False
+# DISABLE_MAIN_ATOM_FEED = False
+# DISABLE_MAIN_RSS_FEED = False
+
+# Add the absolute paths to directories containing plugins to use them.
+# For example, the `plugins` directory of your clone of the Nikola plugins
+# repository.
+# EXTRA_PLUGINS_DIRS = []
+
+# Add the absolute paths to directories containing themes to use them.
+# For example, the `v7` directory of your clone of the Nikola themes
+# repository.
+# EXTRA_THEMES_DIRS = []
+
+# List of regular expressions, links matching them will always be considered
+# valid by "nikola check -l"
+# LINK_CHECK_WHITELIST = []
+
+# If set to True, enable optional hyphenation in your posts (requires pyphen)
+# Enabling hyphenation has been shown to break math support in some cases,
+# use with caution.
+# HYPHENATE = False
+
+# The <hN> tags in HTML generated by certain compilers (reST/Markdown)
+# will be demoted by that much (1 → h1 will become h2 and so on)
+# This was a hidden feature of the Markdown and reST compilers in the
+# past.  Useful especially if your post titles are in <h1> tags too, for
+# example.
+# (defaults to 1.)
+# DEMOTE_HEADERS = 1
+
+# If you don’t like slugified file names ([a-z0-9] and a literal dash),
+# and would prefer to use all the characters your file system allows.
+# USE WITH CARE!  This is also not guaranteed to be perfect, and may
+# sometimes crash Nikola, your web server, or eat your cat.
+# USE_SLUGIFY = True
+
+# If set to True, the tags 'draft', 'mathjax' and 'private' have special
+# meaning. If set to False, these tags are handled like regular tags.
+USE_TAG_METADATA = False
+
+# If set to True, a warning is issued if one of the 'draft', 'mathjax'
+# and 'private' tags are found in a post. Useful for checking that
+# migration was successful.
+WARN_ABOUT_TAG_METADATA = False
+
+# Templates will use those filters, along with the defaults.
+# Consult your engine's documentation on filters if you need help defining
+# those.
+# TEMPLATE_FILTERS = {}
+
+# Put in global_context things you want available on all your templates.
+# It can be anything, data, functions, modules, etc.
+GLOBAL_CONTEXT = {
+}
+
+
+# Add functions here and they will be called with template
+# GLOBAL_CONTEXT as parameter when the template is about to be
+# rendered
+GLOBAL_CONTEXT_FILLER = []

--- a/docs/web/github_readme_to_pages.sh
+++ b/docs/web/github_readme_to_pages.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+
+function GenerateMarkdownHeader() {
+  TITLE="$1"
+  SLUG="$2"
+  DATE="$(date +'%Y-%m-%d %H:%M:%S UTC%:z')"
+  cat <<EOF
+<!--
+.. title: $TITLE
+.. slug: $SLUG
+.. date: $DATE
+.. tags:
+.. category:
+.. link:
+.. description:
+.. type: text
+-->
+EOF
+}
+
+if [[ -n "$1" ]]; then
+  BRANCH="$1"
+else
+  BRANCH="master"
+fi
+
+OUTPUT_DIR=./pages
+
+# main page
+OUTPUT_FILE="$OUTPUT_DIR"/index.md
+> $OUTPUT_FILE
+GenerateMarkdownHeader " " "index" >> $OUTPUT_FILE
+curl -sSL --silent https://raw.githubusercontent.com/idaholab/Malcolm/$BRANCH/README.md \
+  | sed '/name="TableOfContents"/,$d' \
+  | sed 's/^# Malcolm$//' \
+  | sed "s@\](https://github.com/idaholab/[Mm]alcolm/*)@\](https://malcolm.fyi/)@g" \
+  | sed "s@/[Mm]alcolm/blob/master/@/Malcolm/blob/$BRANCH/@g" \
+  | sed "s@\](\./@\](https://raw.githubusercontent.com/idaholab/Malcolm/$BRANCH/@g" \
+  >> $OUTPUT_FILE
+
+# documentation page
+OUTPUT_FILE="$OUTPUT_DIR"/documentation.md
+> $OUTPUT_FILE
+GenerateMarkdownHeader "Documentation" "documentation" >> $OUTPUT_FILE
+curl -sSL --silent https://raw.githubusercontent.com/idaholab/Malcolm/$BRANCH/README.md \
+  | sed '0,/name="TableOfContents"/d' \
+  | sed '/## Other Software/,$d' \
+  | sed "s@\](https://github.com/idaholab/[Mm]alcolm/*)@\](https://malcolm.fyi/)@g" \
+  | sed "s@/[Mm]alcolm/blob/master/@/Malcolm/blob/$BRANCH/@g" \
+  | sed "s@\](\./@\](https://raw.githubusercontent.com/idaholab/Malcolm/$BRANCH/@g" \
+  >> $OUTPUT_FILE
+
+# hedgehog Linux page
+OUTPUT_FILE="$OUTPUT_DIR"/hedgehog.md
+> $OUTPUT_FILE
+GenerateMarkdownHeader " " "hedgehog" >> $OUTPUT_FILE
+curl -sSL --silent https://raw.githubusercontent.com/idaholab/Malcolm/$BRANCH/sensor-iso/README.md \
+  | sed "s@\](https://github.com/idaholab/[Mm]alcolm/*)@\](https://malcolm.fyi/)@g" \
+  | sed "s@/[Mm]alcolm/blob/master/@/Malcolm/blob/$BRANCH/@g" \
+  | sed "s@\](\./docs/Notes.md@\](https://github.com/idaholab/Malcolm/blob/$BRANCH/sensor-iso/docs/Notes.md)@g" \
+  | sed "s@\](\./@\](https://raw.githubusercontent.com/idaholab/Malcolm/$BRANCH/sensor-iso/@g" \
+  >> $OUTPUT_FILE
+
+# build site
+nikola clean -a
+nikola build

--- a/docs/web/requirements.txt
+++ b/docs/web/requirements.txt
@@ -1,0 +1,1 @@
+Nikola[extras]

--- a/nginx/ca-trust/.gitignore
+++ b/nginx/ca-trust/.gitignore
@@ -1,0 +1,3 @@
+*
+!.gitignore
+

--- a/nginx/scripts/docker_entrypoint.sh
+++ b/nginx/scripts/docker_entrypoint.sh
@@ -65,13 +65,18 @@ if (( ${#CA_FILES} )) ; then
   rm -f "$CA_TRUST_RUN_DIR"/*
   pushd "$CA_TRUST_RUN_DIR" >/dev/null 2>&1
   if cp "$CA_TRUST_HOST_DIR"/* ./ ; then
+    # create hash symlinks
     c_rehash -compat .
+
+    # variables for stunnel config
     STUNNEL_CA_PATH_LINE="CApath = $CA_TRUST_RUN_DIR"
     [[ -n $NGINX_LDAP_TLS_STUNNEL_VERIFY_LEVEL ]] && STUNNEL_VERIFY_LINE="verify = $NGINX_LDAP_TLS_STUNNEL_VERIFY_LEVEL" || STUNNEL_VERIFY_LINE="verify = 2"
     [[ -n $NGINX_LDAP_TLS_STUNNEL_CHECK_HOST ]] && STUNNEL_CHECK_HOST_LINE="checkHost = $NGINX_LDAP_TLS_STUNNEL_CHECK_HOST"
     [[ -n $NGINX_LDAP_TLS_STUNNEL_CHECK_IP ]] && STUNNEL_CHECK_IP_LINE="checkIP = $NGINX_LDAP_TLS_STUNNEL_CHECK_IP"
+
+    # variables for nginx config
     NGINX_LDAP_CA_PATH_LINE="  ssl_ca_dir $CA_TRUST_RUN_DIR;"
-    NGINX_LDAP_CHECK_REMOTE_CERT_LINE="  ssl_check_cert on;"
+    ( [[ -n $NGINX_LDAP_TLS_STUNNEL_CHECK_HOST ]] || [[ -n $NGINX_LDAP_TLS_STUNNEL_CHECK_IP ]] ) && NGINX_LDAP_CHECK_REMOTE_CERT_LINE="  ssl_check_cert on;" || NGINX_LDAP_CHECK_REMOTE_CERT_LINE="  ssl_check_cert chain;"
   fi
   popd >/dev/null 2>&1
 fi

--- a/nginx/scripts/docker_entrypoint.sh
+++ b/nginx/scripts/docker_entrypoint.sh
@@ -49,6 +49,33 @@ NGINX_RUNTIME_LDAP_CONF=/etc/nginx/nginx_ldap_rt.conf
 # config file for stunnel if using stunnel to issue LDAP StartTLS function
 STUNNEL_CONF=/etc/stunnel/stunnel.conf
 
+CA_TRUST_HOST_DIR=/etc/nginx/ca-trust
+CA_TRUST_RUN_DIR=/var/run/ca-trust
+
+# copy trusted CA certs to runtime directory and c_rehash them to create symlinks
+STUNNEL_CA_PATH_LINE=""
+STUNNEL_VERIFY_LINE=""
+STUNNEL_CHECK_HOST_LINE=""
+STUNNEL_CHECK_IP_LINE=""
+NGINX_LDAP_CA_PATH_LINE=""
+NGINX_LDAP_CHECK_REMOTE_CERT_LINE=""
+mkdir -p "$CA_TRUST_RUN_DIR"
+CA_FILES=$(shopt -s nullglob dotglob; echo "$CA_TRUST_HOST_DIR"/*)
+if (( ${#CA_FILES} )) ; then
+  rm -f "$CA_TRUST_RUN_DIR"/*
+  pushd "$CA_TRUST_RUN_DIR" >/dev/null 2>&1
+  if cp "$CA_TRUST_HOST_DIR"/* ./ ; then
+    c_rehash -compat .
+    STUNNEL_CA_PATH_LINE="CApath = $CA_TRUST_RUN_DIR"
+    [[ -n $NGINX_LDAP_TLS_STUNNEL_VERIFY_LEVEL ]] && STUNNEL_VERIFY_LINE="verify = $NGINX_LDAP_TLS_STUNNEL_VERIFY_LEVEL" || STUNNEL_VERIFY_LINE="verify = 2"
+    [[ -n $NGINX_LDAP_TLS_STUNNEL_CHECK_HOST ]] && STUNNEL_CHECK_HOST_LINE="checkHost = $NGINX_LDAP_TLS_STUNNEL_CHECK_HOST"
+    [[ -n $NGINX_LDAP_TLS_STUNNEL_CHECK_IP ]] && STUNNEL_CHECK_IP_LINE="checkIP = $NGINX_LDAP_TLS_STUNNEL_CHECK_IP"
+    NGINX_LDAP_CA_PATH_LINE="  ssl_ca_dir $CA_TRUST_RUN_DIR;"
+    NGINX_LDAP_CHECK_REMOTE_CERT_LINE="  ssl_check_cert on;"
+  fi
+  popd >/dev/null 2>&1
+fi
+
 if [[ -z $NGINX_BASIC_AUTH ]] || [[ "$NGINX_BASIC_AUTH" == "true" ]]; then
   # doing HTTP basic auth instead of ldap
 
@@ -62,40 +89,40 @@ else
   # point nginx_auth_rt.conf to nginx_auth_ldap.conf
   ln -sf "$NGINX_LDAP_AUTH_CONF" "$NGINX_RUNTIME_AUTH_CONF"
 
+  # parse URL information out of user ldap configuration
+  # example:
+  #   url "ldap://localhost:3268/DC=ds,DC=example,DC=com?sAMAccountName?sub?(objectClass=person)";
+  #             "url"    quote protocol h/p    uri
+  #             ↓        ↓     ↓        ↓      ↓
+  PATTERN='^(\s*url\s+)([''"]?)(\w+)://([^/]+)(/.*)$'
+
+  unset HEADER
+  unset OPEN_QUOTE
+  unset PROTOCOL
+  unset REMOTE_HOST
+  unset REMOTE_PORT
+  unset URI_TO_END
+
+  URL_LINE_NUM=0
+  READ_LINE_NUM=0
+  while IFS= read -r LINE; do
+    READ_LINE_NUM=$((READ_LINE_NUM+1))
+    if [[ $LINE =~ $PATTERN ]]; then
+      URL_LINE_NUM=$READ_LINE_NUM
+      HEADER=${BASH_REMATCH[1]}
+      OPEN_QUOTE=${BASH_REMATCH[2]}
+      PROTOCOL=${BASH_REMATCH[3]}
+      REMOTE=${BASH_REMATCH[4]}
+      REMOTE_ARR=(${REMOTE//:/ })
+      [[ -n ${REMOTE_ARR[0]} ]] && REMOTE_HOST=${REMOTE_ARR[0]}
+      [[ -n ${REMOTE_ARR[1]} ]] && REMOTE_PORT=${REMOTE_ARR[1]} || REMOTE_PORT=3268
+      URI_TO_END=${BASH_REMATCH[5]}
+      break
+    fi
+  done < "$NGINX_LDAP_USER_CONF"
+
   if [[ "$NGINX_LDAP_TLS_STUNNEL" == "true" ]]; then
     # user provided LDAP configuration, but we need to tweak it and set up stunnel to issue StartTLS
-
-    # parse URL out of user ldap configuration to set up stunnel
-    # example:
-    #   url "ldap://localhost:3268/DC=ds,DC=example,DC=com?sAMAccountName?sub?(objectClass=person)";
-    #             "url"    quote protocol h/p    uri
-    #             ↓        ↓     ↓        ↓      ↓
-    PATTERN='^(\s*url\s+)([''"]?)(\w+)://([^/]+)(/.*)$'
-
-    unset HEADER
-    unset OPEN_QUOTE
-    unset PROTOCOL
-    unset REMOTE_HOST
-    unset REMOTE_PORT
-    unset URI_TO_END
-
-    URL_LINE_NUM=0
-    READ_LINE_NUM=0
-    while IFS= read -r LINE; do
-      READ_LINE_NUM=$((READ_LINE_NUM+1))
-      if [[ $LINE =~ $PATTERN ]]; then
-        URL_LINE_NUM=$READ_LINE_NUM
-        HEADER=${BASH_REMATCH[1]}
-        OPEN_QUOTE=${BASH_REMATCH[2]}
-        PROTOCOL=${BASH_REMATCH[3]}
-        REMOTE=${BASH_REMATCH[4]}
-        REMOTE_ARR=(${REMOTE//:/ })
-        [[ -n ${REMOTE_ARR[0]} ]] && REMOTE_HOST=${REMOTE_ARR[0]}
-        [[ -n ${REMOTE_ARR[1]} ]] && REMOTE_PORT=${REMOTE_ARR[1]} || REMOTE_PORT=3268
-        URI_TO_END=${BASH_REMATCH[5]}
-        break
-      fi
-    done < "$NGINX_LDAP_USER_CONF"
 
     if [[ -z $REMOTE_HOST ]]; then
       # missing LDAP info needed to configure tunnel, abort
@@ -124,8 +151,12 @@ pid = /tmp/stunnel.pid
 socket = l:TCP_NODELAY=1
 socket = r:TCP_NODELAY=1
 client = yes
-cert = /etc/stunnel/stunnel.pem
 foreground = yes
+cert = /etc/stunnel/stunnel.pem
+$STUNNEL_CA_PATH_LINE
+$STUNNEL_VERIFY_LINE
+$STUNNEL_CHECK_HOST_LINE
+$STUNNEL_CHECK_IP_LINE
 
 [stunnel.ldap_start_tls]
 accept = localhost:$LOCAL_PORT
@@ -148,11 +179,22 @@ EOF
 
   else
     # we're doing either LDAP or LDAPS, but not StartTLS, so we don't need to use stunnel.
-    # leave LDAP configuration as the user specified without modifications.
-    ln -sf "$NGINX_LDAP_USER_CONF" "$NGINX_RUNTIME_LDAP_CONF"
-  fi
+    # however, we do want to set SSL CA trust stuff if specified, so do that
+    rm -f "$NGINX_RUNTIME_LDAP_CONF"
+    touch "$NGINX_RUNTIME_LDAP_CONF"
+    READ_LINE_NUM=0
+    while IFS= read -r LINE; do
+      READ_LINE_NUM=$((READ_LINE_NUM+1))
+      echo "$LINE" >> "$NGINX_RUNTIME_LDAP_CONF"
+      if (( $URL_LINE_NUM == $READ_LINE_NUM )); then
+        echo "$NGINX_LDAP_CHECK_REMOTE_CERT_LINE" >> "$NGINX_RUNTIME_LDAP_CONF"
+        echo "$NGINX_LDAP_CA_PATH_LINE" >> "$NGINX_RUNTIME_LDAP_CONF"
+      fi
+    done < "$NGINX_LDAP_USER_CONF"
 
-fi
+  fi # stunnel/starttls vs. ldap/ldaps
+
+fi # basic vs. ldap
 
 # start supervisor (which will spawn nginx, stunnel, etc.) or whatever the default command is
 exec "$@"

--- a/scripts/control.py
+++ b/scripts/control.py
@@ -145,7 +145,7 @@ def start():
   # make sure the auth files exist. if we are in an interactive shell and we're
   # missing any of the auth files, prompt to create them now
   if sys.__stdin__.isatty() and (not MalcolmAuthFilesExist()):
-    check_call(['bash', os.path.join(ScriptPath, 'auth_setup')])
+    authSetup()
 
   # still missing? sorry charlie
   if (not MalcolmAuthFilesExist()):
@@ -173,6 +173,7 @@ def start():
   # make sure some directories exist before we start
   for path in [os.path.join(MalcolmPath, 'elasticsearch'),
                os.path.join(MalcolmPath, 'elasticsearch-backup'),
+               os.path.join(MalcolmPath, os.path.join('nginx', 'ca-trust')),
                os.path.join(MalcolmPath, os.path.join('pcap', 'upload')),
                os.path.join(MalcolmPath, os.path.join('pcap', 'processed')),
                os.path.join(MalcolmPath, os.path.join('zeek-logs', 'current')),

--- a/scripts/malcolm_appliance_packager.sh
+++ b/scripts/malcolm_appliance_packager.sh
@@ -62,6 +62,7 @@ if mkdir "$DESTDIR"; then
   trap "cleanup" EXIT
 
   mkdir $VERBOSE -p "$DESTDIR/nginx/certs/"
+  mkdir $VERBOSE -p "$DESTDIR/nginx/ca-trust/"
   mkdir $VERBOSE -p "$DESTDIR/htadmin/"
   mkdir $VERBOSE -p "$DESTDIR/logstash/certs/"
   mkdir $VERBOSE -p "$DESTDIR/filebeat/certs/"

--- a/sensor-iso/README.md
+++ b/sensor-iso/README.md
@@ -398,7 +398,7 @@ Building the ISO may take 90 minutes or more depending on your system. As the bu
 
 ```
 …
-Finished, created "/sensor-build/hedgehog-2.0.2.iso"
+Finished, created "/sensor-build/hedgehog-2.0.3.iso"
 …
 ```
 


### PR DESCRIPTION
This addresses #128. 

For LDAP authentication, for encrypted connections (whether using **StartTLS** or **LDAPS**), Malcolm will require and verify certificates when one or more trusted CA certificate files are placed in the `nginx/ca-trust/` directory. Otherwise, any certificate presented by the domain server will be accepted.

