### PR TITLE
Improve root user check.

### DIFF
--- a/scripts/control.py
+++ b/scripts/control.py
@@ -610,7 +610,7 @@ def main():
   os.chdir(MalcolmPath)
 
   # don't run this as root
-  if (pyPlatform != PLATFORM_WINDOWS) and (('SUDO_UID' in os.environ.keys()) or (getpass.getuser() == 'root')):
+  if (pyPlatform != PLATFORM_WINDOWS) and ((os.getuid() == 0) or (os.geteuid() == 0) or (getpass.getuser() == 'root')):
     raise Exception('{} should not be run as root'.format(ScriptName))
 
   # make sure docker/docker-compose is available


### PR DESCRIPTION
Replace check for sudo specific environmental variable with check for
the current uid and effective uid.

The check for the user being 'root' is technically superfluous but I've
left it in.