### PR TITLE
Deny access to uploaded files

### DIFF
--- a/file-upload/nginx/sites-available/default
+++ b/file-upload/nginx/sites-available/default
@@ -8,6 +8,11 @@ server {
     root /var/www/upload;
     index index.php index.html index.htm;
 
+    location ^~ /server/php/files {
+        deny all;
+        return 404;
+    }
+
     location ~ \.php$ {
         include snippets/fastcgi-php.conf;
         fastcgi_buffers 16 64k;


### PR DESCRIPTION
## 🗣 Description ##

Added deny section to nginx configuration for pcap-upload docker container to deny access to uploaded files.

## 💭 Motivation and context ##

This PR fixes a possible RCE where an authenticated user can upload a php webshell (or many to beat the file processor) where they could gain access to the entire Malcolm docker network and all files.

## 🧪 Testing ##

1) Used docker exec to connect to a bash shell within the malcolm_upload_1 container
2) Used vi to edit `/etc/nginx/sites-enabled/default`
3) Added lines from PR
4) Issued `nginx -s reload`
5) Used web browser to check with url: https://<Malcolm_IP>/server/php/files/.gitignore

## 📷 Screenshots (if appropriate) ##

Before:
<img width="961" alt="Screenshot 2021-06-14 104652" src="https://user-images.githubusercontent.com/6990300/121911703-fd190680-ccfd-11eb-86d3-e8440c409cb5.png">
After:
<img width="960" alt="Screenshot 2021-06-14 104301" src="https://user-images.githubusercontent.com/6990300/121911718-0013f700-ccfe-11eb-97b4-eda9cce1c8dd.png">

## ✅ Checklist ##

* [ ] This PR has an informative and human-readable title.
* [ ] Changes are limited to a single goal - _eschew scope creep!_
* [ ] _All_ future TODOs are captured in issues, which are referenced
      in code comments.
* [ ] All relevant type-of-change labels have been added.
* [ ] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
* [ ] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
* [ ] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
* [ ] Tests have been added and/or modified to cover the changes in this PR.
* [ ] All new and existing tests pass.
