### PR TITLE
Add package java-1.8.0-openjdk to be able to build logstash container.

### DIFF
--- a/Dockerfiles/logstash.Dockerfile
+++ b/Dockerfiles/logstash.Dockerfile
@@ -12,6 +12,7 @@ RUN amazon-linux-extras install -y epel && \
       gcc-c++ \
       glibc-devel \
       glibc-headers \
+      java-1.8.0-openjdk \
       java-latest-openjdk-devel \
       libffi-devel \
       libtool \


### PR DESCRIPTION
Seems to be a change in the base Docker image and the current version of logstash fails to build with a reference to missing javac. Add java-1.8.0-openjdk according to error message.

## 🗣 Description ##

Add package java-1.8.0-openjdk to logstash container.

## 💭 Motivation and context ##

When building with current version of the base Docker container an error is reported of missing javac.

## 🧪 Testing ##

Try to build the container locally without fails. Building with the proposed fix solves the problem a container images is generated.

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).

