### PR TITLE
Modify zeek's logstash pipeline to drop event from logs name that con…

### DIFF
--- a/logstash/pipelines/zeek/11_zeek_logs.conf
+++ b/logstash/pipelines/zeek/11_zeek_logs.conf
@@ -4313,9 +4313,10 @@ filter {
 
   } else {
 
-    if ([log_source] =~ /\.\d{4}-\d{2}-\d{2}-\d{2}-\d{2}-\d{2}$/) {
+    if ([log_source] =~ /\.\d{4}-\d{2}-\d{2}-\d{2}-\d{2}-\d{2}$/ or 
+	    [log_source] =~ /\.\d{4}_\d{2}_\d{2}_\d{2}_\d{2}_\d{2}$/ ) {
       # filebeat caught a file right in the middle of being renamed/moved (ie., renamed from conn.log to
-      # conn.2020-01-16-14-00-00.log). this has actually already been processed, so ignore this event.
+      # conn.2020-01-16-14-00-00.log or conn.2020_01_16_14_00_00.log ). this has actually already been processed, so ignore this event.
       drop { id => "drop_renamed_logfile" }
 
     } else {


### PR DESCRIPTION
Zeek sometimes generate logs like conn.2020_01_16_14_00_00.log. It will makes a lot of mess because it will generate custom field also like [zeek][conn.2020_01_16_14_00_00][column10] and so on.  The current logstash pipeline configuration has handled it for logs name like conn.2020-01-16-14-00-00.log.


## 🗣 Description ##

Adding the if condition in Zeek's logstash pipeline to drop log with name pattern like conn.2020_01_16_14_00_00.log.

## 💭 Motivation and context ##

Because right now if the log name pattern like "conn.2020_01_16_14_00_00.log" occured, it will messed up the field name in Opensearch

## 🧪 Testing ##
Build the logstash container locally without failed. And when it integrate with Zeek, the logs still ingest properly.


## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [ ] This PR has an informative and human-readable title.
- [ ] Changes are limited to a single goal - *eschew scope creep!*
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.


## ✅ Pre-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been approved. -->

- [ ] Revert dependencies to default branches.
- [ ] Finalize version.

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->

- [ ] Add a tag or create a release.
