### PR TITLE
Update control.py

### DIFF
--- a/scripts/control.py
+++ b/scripts/control.py
@@ -1392,6 +1392,8 @@ def main():
             dockerComposeBin = '/usr/local/opt/docker-compose/bin/docker-compose'
         elif os.path.isfile('/usr/local/bin/docker-compose'):
             dockerComposeBin = '/usr/local/bin/docker-compose'
+        elif os.path.isfile('/usr/bin/docker-compose'):
+            dockerComposeBin = '/usr/bin/docker-compose'
         else:
             dockerComposeBin = 'docker-compose'
         err, out = run_process([dockerBin, 'info'], debug=args.debug)


### PR DESCRIPTION
Added ubuntu 22.04 docker-compose path of /usr/bin/docker-compose as it is not in local.

# Ubuntu 22.04 puts docker-compose in /usr/bin/docker-compose control.py does not currently check for that location and so the script fails.#

