### PR TITLE
Opensearch statistics are now parsed correctly when only a one node is present

### DIFF
--- a/shared/bin/opensearch_index_size_prune.py
+++ b/shared/bin/opensearch_index_size_prune.py
@@ -220,18 +220,16 @@ def main():
         osInfo = osInfoResponse.json()
 
         # normalize allocation statistics' sizes (eg., 100mb) into bytes
-        if len(osInfo) > 1:
-            esDiskUsageStats = []
-            for stat in osInfo:
-                if ('node' in stat) and (stat['node'] != 'UNASSIGNED'):
-                    esDiskUsageStats.append(
-                        {
-                            key: humanfriendly.parse_size(value)
-                            if re.match(r'^\d+(\.\d+)?\s*[kmgtp]?b$', value, flags=re.IGNORECASE)
-                            else value
-                            for (key, value) in stat.items()
-                        }
-                    )
+        for stat in osInfo:
+            if ('node' in stat) and (stat['node'] != 'UNASSIGNED'):
+                esDiskUsageStats.append(
+                    {
+                        key: humanfriendly.parse_size(value)
+                        if re.match(r'^\d+(\.\d+)?\s*[kmgtp]?b$', value, flags=re.IGNORECASE)
+                        else value
+                        for (key, value) in stat.items()
+                    }
+                )
 
         if debug:
             eprint(json.dumps(esDiskUsageStats))


### PR DESCRIPTION
When a single node is present, the Opensearch statistics wouldn't get parsed correctly as a result of an off-by-one condition. Changing the right value from a 1 to a 0 would suffice, but removing the if statement all together is preferable and won't impact the functionality any further.