### PR TITLE
Added -n argument to script/logs akin to 'tail -n ...'

### DIFF
--- a/scripts/control.py
+++ b/scripts/control.py
@@ -358,8 +358,17 @@ def logs():
     )
     print("\n".join(out))
 
+    if args.logLineCount is None:
+        args.logLineCount = 'all'
+
     process = Popen(
-        [dockerComposeBin, '-f', args.composeFile, 'logs', '-f', args.service][: 6 if args.service is not None else -1],
+        [
+            dockerComposeBin,
+            '-f', args.composeFile,
+            'logs',
+            '--tail', str(args.logLineCount),
+            '-f', args.service
+        ][: 6 if args.service is not None else -1],
         env=osEnv,
         stdout=PIPE,
     )
@@ -1294,6 +1303,16 @@ def main():
     )
     parser.add_argument(
         '-l', '--logs', dest='cmdLogs', type=str2bool, nargs='?', const=True, default=False, help="Tail Malcolm logs"
+    )
+    parser.add_argument(
+        '-n',
+        '--lines',
+        dest='logLineCount',
+        type=posInt,
+        nargs='?',
+        const=False,
+        default=None,
+        help='Number of log lines to output. Outputs all lines by default (only for logs operation)',
     )
     parser.add_argument(
         '--start', dest='cmdStart', type=str2bool, nargs='?', const=True, default=False, help="Start Malcolm"

--- a/scripts/malcolm_common.py
+++ b/scripts/malcolm_common.py
@@ -3,6 +3,7 @@
 
 # Copyright (c) 2023 Battelle Energy Alliance, LLC.  All rights reserved.
 
+import argparse
 import contextlib
 import getpass
 import importlib
@@ -570,6 +571,17 @@ def str2bool(v):
     else:
         raise ValueError("Boolean value expected")
 
+###################################################################################################
+# Dies if $value isn't positive. NoneType is also acceptable
+def posInt(value):
+    if value is None:
+        return None
+
+    ivalue = int(value)
+    if ivalue <= 0:
+        raise argparse.ArgumentTypeError("{} is an invalid positive int value".format(value))
+
+    return ivalue
 
 ###################################################################################################
 # determine if a program/script exists and is executable in the system path


### PR DESCRIPTION
The argument is completely optional, passing positive integer $N to `docker-compose -f ... logs --tail $N`. `--tail` is documented [here](https://docs.docker.com/engine/reference/commandline/compose_logs/). On omission no functionality is changed.