### PR TITLE
Change pcap file upload logging to be more descriptive.

### DIFF
--- a/pcap-monitor/scripts/watch-pcap-uploads-folder.py
+++ b/pcap-monitor/scripts/watch-pcap-uploads-folder.py
@@ -88,7 +88,7 @@ def file_processor(pathname, **kwargs):
 
             else:
                 # unhandled file type uploaded, delete it
-                logger.error(f"{scriptName}: Invalid file type uploade {fileMime}/{fileType}")
+                logger.error(f"{scriptName}: Invalid file type uploaded {fileMime}/{fileType}")
                 logger.error(f"{scriptName}: Deleting {pathname}")
                 os.unlink(pathname)
 

--- a/pcap-monitor/scripts/watch-pcap-uploads-folder.py
+++ b/pcap-monitor/scripts/watch-pcap-uploads-folder.py
@@ -88,7 +88,8 @@ def file_processor(pathname, **kwargs):
 
             else:
                 # unhandled file type uploaded, delete it
-                logger.warning(f"{scriptName}:\t🗑\t{pathname} ({fileMime}/{fileType})")
+                logger.error(f"{scriptName}: Invalid file type uploade {fileMime}/{fileType}")
+                logger.error(f"{scriptName}: Deleting {pathname}")
                 os.unlink(pathname)
 
         except Exception as genericError:


### PR DESCRIPTION
## 🗣 Description ##
Changing error log for file upload when there's an invalid file type uploaded. Previously just printed a single trashcan emoji (🗑️), changed to be more descriptive.

## 💭 Motivation and context ##
When debugging why I couldn't upload a PCAP file to Malcolm I kept getting the below error.

```
WARNING: watch-pcap-uploads-folder.py:	🗑	/pcap/upload/AUTOSURICATA,AUTOZEEK,all,cloud,azure,USERTAG,cloud.pcapng (application/octet-stream/pcapng capture file - version 1.0)
```

This is minimally descriptive only providing a trashcan emoji along with the file name and mime type. The message can be assumed that your submitted file was immediately deleted. While the attached filename and mime type seems much more descriptive of what was uploaded, but not to why the error occurred.

This pull request changed this single line error to two much more descriptive errors:

```
ERROR: watch-pcap-uploads-folder.py: Invalid file type uploaded application/octet-stream/pcapng capture file - version 1.0
ERROR: watch-pcap-uploads-folder.py: Deleting /pcap/upload/AUTOSURICATA,AUTOZEEK,all,cloud,azure,USERTAG,cloud.pcapng
```

While I like the flair emojis give scripts, putting them into error logs is a misstep and either further obfuscates the error at hand, or makes it much more difficult to parse.

## 🧪 Testing ##
Splits one print statement into two, removes an emoji, don't really think this applies.

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [ ] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.

## ✅ Pre-merge checklist ##
- [ ] Revert dependencies to default branches.
- [ ] Finalize version.

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->

- [ ] Create a release.
