### PR TITLE
fixed errors when running appliance packager on macOS

### DIFF
--- a/scripts/malcolm_appliance_packager.sh
+++ b/scripts/malcolm_appliance_packager.sh
@@ -34,7 +34,11 @@ CURRENT_REV_SHA="$(git rev-parse --short --verify HEAD)"
 if [ -z "$CURRENT_REV_SHA" ]; then
   CURRENT_REV_TAG="$(date +%Y.%m.%d_%H:%M:%S)"
 else
-  CURRENT_REV_DATE="$(git log -1 --format="%at" | xargs -I{} date -d @{} +%Y%m%d_%H%M%S)"
+  if [[ "$(uname -s)" == 'Darwin' ]]; then
+    CURRENT_REV_DATE="$(git log -1 --format="%at" | xargs -I{} date -r {} +%Y%m%d_%H%M%S)"
+  else
+    CURRENT_REV_DATE="$(git log -1 --format="%at" | xargs -I{} date -d @{} +%Y%m%d_%H%M%S)"
+  fi
   if [ -z "$CURRENT_REV_DATE" ]; then
     CURRENT_REV_TAG="$(date +%Y.%m.%d_%H:%M:%S)"
   fi
@@ -143,7 +147,11 @@ if mkdir "$DESTDIR"; then
   cp $VERBOSE "$SCRIPT_PATH/malcolm_kubernetes.py" "$RUN_PATH/"
   cp $VERBOSE "$SCRIPT_PATH/malcolm_utils.py" "$RUN_PATH/"
 
-  tar $VERBOSE --numeric-owner --owner=0 --group=0 -czf "$DESTNAME" "./$(basename $DESTDIR)/"
+  if [[ "$(uname -s)" == "Darwin" ]]; then
+      tar $VERBOSE -czf "$DESTNAME" "./$(basename $DESTDIR)/"
+  else
+      tar $VERBOSE --numeric-owner --owner=0 --group=0 -czf "$DESTNAME" "./$(basename $DESTDIR)/"
+  fi
   echo "Packaged Malcolm to \"$DESTNAME\""
 
   unset CONFIRMATION


### PR DESCRIPTION
🗣 Description

This pull request modifies both the tar and date commands to conditionally adapt their behavior depending on the underlying operating system.
	1.	tar Command: The script checks whether it’s running on macOS or Linux using the uname command. For macOS, the tar command is executed without the --owner and --group flags due to compatibility issues with bsdtar. For Linux, the tar command includes the --numeric-owner, --owner=0, and --group=0 flags to set file ownership to root. This ensures compatibility across both platforms.
	2.	date Command: The date command was adjusted to handle platform-specific differences. On Linux, it uses the standard date format, while on macOS, adjustments are made to accommodate slight differences in how the date command handles formatting.

This update ensures that both commands work seamlessly on macOS and Linux systems, resolving issues with incompatible options.

💭 Motivation and context

These changes are required to address platform-specific differences in the tar and date commands. macOS uses bsdtar, which does not support the --owner and --group flags, while Linux requires them for setting file ownership. Similarly, the date command on macOS differs slightly from its Linux counterpart. By implementing these adjustments, the script will now function correctly on both operating systems without errors.

🧪 Testing

The changes were tested by running the script on macOS. On macOS, the script ran without the --owner and --group options in tar, and the date command executed with the correct format. 

✅ Pre-approval checklist

	•	This PR has an informative and human-readable title.
	•	Changes are limited to a single goal - eschew scope creep!
	•	These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
	•	All relevant repo and/or project documentation has been updated to reflect the changes in this PR.

ToDo: 	•	Add relevant type of type-of-change labels 
