### PR TITLE
Fix pcap processor to retain ordering of user tags

### DIFF
--- a/shared/bin/pcap_processor.py
+++ b/shared/bin/pcap_processor.py
@@ -193,7 +193,7 @@ def arkimeCaptureFileWorker(arkimeWorkerArgs):
                         )
                         if extraTags and isinstance(extraTags, list):
                             fileInfo[FILE_INFO_DICT_TAGS].extend(extraTags)
-                        fileInfo[FILE_INFO_DICT_TAGS] = list(set(fileInfo[FILE_INFO_DICT_TAGS]))
+                        fileInfo[FILE_INFO_DICT_TAGS] = list(dict.fromkeys(fileInfo[FILE_INFO_DICT_TAGS]))
                         logger.info(f"{scriptName}[{workerId}]:\t🔎\t{fileInfo}")
 
                         # if this is an uploaded PCAP (not captured "live"")
@@ -317,7 +317,7 @@ def zeekFileWorker(zeekWorkerArgs):
                         )
                         if extraTags and isinstance(extraTags, list):
                             fileInfo[FILE_INFO_DICT_TAGS].extend(extraTags)
-                        fileInfo[FILE_INFO_DICT_TAGS] = list(set(fileInfo[FILE_INFO_DICT_TAGS]))
+                        fileInfo[FILE_INFO_DICT_TAGS] = list(dict.fromkeys(fileInfo[FILE_INFO_DICT_TAGS]))
                         logger.info(f"{scriptName}[{workerId}]:\t🔎\t{fileInfo}")
 
                         # create a temporary work directory where zeek will be executed to generate the log files
@@ -477,7 +477,7 @@ def suricataFileWorker(suricataWorkerArgs):
                     )
                     if extraTags and isinstance(extraTags, list):
                         fileInfo[FILE_INFO_DICT_TAGS].extend(extraTags)
-                    fileInfo[FILE_INFO_DICT_TAGS] = list(set(fileInfo[FILE_INFO_DICT_TAGS]))
+                    fileInfo[FILE_INFO_DICT_TAGS] = list(dict.fromkeys(fileInfo[FILE_INFO_DICT_TAGS]))
                     logger.info(f"{scriptName}[{workerId}]:\t🔎\t{fileInfo}")
 
                     # Create unique output directory for this PCAP's suricata output


### PR DESCRIPTION
# Fix pcap processor to retain ordering of user tags

## 🗣 Description ##

The current pcap processor does not retain the order due to the use of set() to remove duplicate tags.

This patch changes the use of set to dict.fromkeys, which retains order (Requires Python 3.7+)

## 💭 Motivation and context ##

When using custom pipelines, the order of supplied tags is desirable.

Resolves #624 

## 🧪 Testing ##

## ✅ Pre-approval checklist ##

- [X] This PR has an informative and human-readable title.
- [X] Changes are limited to a single goal - *eschew scope creep!*
- [X] *All* future TODOs are captured in issues, which are referenced
      in code comments.
- [X] All relevant type-of-change labels have been added.
- [X] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [X] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [X] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
- [X] Tests have been added and/or modified to cover the changes in this PR.
- [X] All new and existing tests pass.

## ✅ Pre-merge checklist ##

- [ ] Revert dependencies to default branches.
- [ ] Finalize version.

## ✅ Post-merge checklist ##

- [ ] Create a release.
