### PR TITLE
Make zeek metrics port configurable

### DIFF
--- a/config/zeek.env.example
+++ b/config/zeek.env.example
@@ -70,6 +70,8 @@ ZEEK_JA4SSH_PACKET_COUNT=200
 ZEEK_LONG_CONN_REPEAT_LAST_DURATION=true
 ZEEK_LONG_CONN_DO_NOTICE=true
 ZEEK_LONG_CONN_DURATIONS=600,1800,3600,43200,86400
+# Change zeek metrics port from default
+ZEEK_METRICS_PORT=
 # Environment variables for tweaking Zeek at runtime (see local.zeek)
 #   Set to true to disable the corresponding feature
 ZEEK_DISABLE_HASH_ALL_FILES=

--- a/shared/bin/zeekdeploy.sh
+++ b/shared/bin/zeekdeploy.sh
@@ -18,6 +18,7 @@
 # ZEEK_LB_PROCS_LOGGER - Defines the number of processors to be assigned to the [loggers](https://docs.zeek.org/en/master/frameworks/cluster.html#logger) (default 1)
 # ZEEK_LB_PROCS_PROXY - Defines the number of processors to be assigned to the [proxies](https://docs.zeek.org/en/master/frameworks/cluster.html#proxy) (default 1)
 # ZEEK_LB_PROCS_CPUS_RESERVED - If ZEEK_LB_PROCS_WORKER_DEFAULT is 0 ("autocalculate"), exclude this number of CPUs from the autocalculation (defaults to 1 (kernel) + 1 (manager) + ZEEK_LB_PROCS_LOGGER + ZEEK_LB_PROCS_PROXY)
+# ZEEK_METRICS_PORT - Defines listen port for Prometheus API
 # ZEEK_PIN_CPUS_WORKER_AUTO - Automatically [pin worker CPUs](https://en.wikipedia.org/wiki/Processor_affinity) (default false)
 # ZEEK_PIN_CPUS_WORKER_n - Explicitly defines the processor IDs to be to be assigned to the group of workers for the *n*-th capture interface (e.g., 0 means "the first CPU"; 12,13,14,15 means "the last four CPUs" on a 16-core system)
 # ZEEK_PIN_CPUS_OTHER_AUTO - automatically pin CPUs for manager, loggers, and proxies if possible (default false)
@@ -218,6 +219,9 @@ else
 fi
 
 
+if [[ -n "$ZEEK_METRICS_PORT" ]]; then
+  echo "MetricsPort = $ZEEK_METRICS_PORT" >> ./zeekctl.cfg
+fi
 
 # completely rewrite node.cfg for one worker per interface
 # see idaholab/Malcolm#36 for details on fine-tuning


### PR DESCRIPTION
## 🗣 Description ##

Allow zeek MetricsPort to be set via environment variable.

## 💭 Motivation and context ##

The default port used for metrics might fail if it's already in use.

> fatal error: Failed to setup Prometheus endpoint: null context when constructing CivetServer. Possible problem binding to port. Error: Failed to setup server ports. Attempted to bind to 0.0.0.0:9993.

Attached patch will provide a way to set MetricsPort via env.

## 🧪 Testing ##

Bind a port (nc -l -p 9993 &), start zeek with live capture, will fail using default port.

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
- [ ] Tests have been added and/or modified to cover the changes in this PR.
- [x] All new and existing tests pass.

## ✅ Pre-merge checklist ##

- [ ] Revert dependencies to default branches.
- [ ] Finalize version.

## ✅ Post-merge checklist ##

- [ ] Create a release.
