### PR TITLE
Update docker_entrypoint.sh

### DIFF
--- a/arkime/scripts/docker_entrypoint.sh
+++ b/arkime/scripts/docker_entrypoint.sh
@@ -189,6 +189,7 @@ if [[ ! -f "${ARKIME_CONFIG_FILE}" ]] && [[ -r "${ARKIME_DIR}"/etc/config.orig.i
         sed -i "s/^\(wisePort=\)/# \1/" "${ARKIME_CONFIG_FILE}"
         sed -i "s/^\(viewerPlugins=\)/# \1/" "${ARKIME_CONFIG_FILE}"
         sed -i '/^\[custom-fields\]/,$d' "${ARKIME_CONFIG_FILE}"
+        sed -i "s|^\(wiseURL=\).*|\1""${ARKIME_WISE_SERVICE_URL}""|" "${ARKIME_CONFIG_FILE}"
     fi
 
     # enable ja4+ plugin if it's present


### PR DESCRIPTION
<!-- markdownlint-disable MD013 -->
# Allow overriding wiseURL when using the hedgehog profile #

## 🗣 Description ##

Add support for a configurable `wiseURL` when running Arkime under the `hedgehog` profile. Previously, the code always fell back to the built-in default (`http://127.0.0.1:8081`), making it impossible to point WISE proxy traffic at a custom host or port in the hedgehog environment. This change reads `wiseURL` from the hedgehog profile’s configuration and passes it through to the capture-offline invocation and Nginx proxy logic.

## 💭 Motivation and context ##

By default the `hedgehog` profile hard-codes WISE to localhost:8081, which doesn’t work in containerized or multi-host deployments. Operators need to route field-lookup traffic to an external WISE service (for example, running on a separate container, a different port, or via a load-balanced endpoint). Without this change, there is no supported way to override the `wiseURL` under the hedgehog profile, leading to capture-offline failures and missing field mappings in Arkime.  
Closes #XYZ (unable to customize wiseURL for hedgehog profile).


## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.  
- [x] Changes are limited to a single goal: enabling `wiseURL` overrides in hedgehog.  
- [x] All relevant type-of-change labels have been added (`enhancement`).  
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.  
- [x] These code changes follow cisagov code standards.  
- [x] All relevant repo and/or project documentation has been updated to reflect the new `wiseURL` setting.  
- [x] Tests have been added and/or modified to cover the changes in this PR.  
- [x] All new and existing tests pass.  
- [x] Bump version via the `bump_version` script (patch) since this is a non-breaking enhancement.

## ✅ Pre-merge checklist ##

- [ ] Revert dependencies to default branches.  
- [ ] Finalize version.

## ✅ Post-merge checklist ##

- [ ] Create a release (necessary if and only if the version was bumped).  

