### PR TITLE
Add DeepWiki documentation badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Malcolm
+[![DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/cisagov/Malcolm)
 
 ![](./docs/images/logo/Malcolm_outline_banner_dark.png)
 


### PR DESCRIPTION
Adds a [DeepWiki](https://deepwiki.com/cisagov/Malcolm) badge to the README for auto-generated interactive documentation.

This is a minimal, single-line addition.