### PR TITLE
fix: add missing closing quote in Redis args in kubernetes/15-redis.yml

### DIFF
--- a/kubernetes/15-redis.yml
+++ b/kubernetes/15-redis.yml
@@ -47,7 +47,7 @@ spec:
                "redis",
                "sh",
                "-c",
-               "redis-server --dir /data --appendonly yes --appendfsync everysec --no-appendfsync-on-rewrite yes --auto-aof-rewrite-percentage 100 --auto-aof-rewrite-min-size $(REDIS_AUTO_AOF_REWRITE_MIN_SIZE) --save '' --maxmemory $(REDIS_MAXMEMORY) --maxmemory-policy $(REDIS_MAXMEMORY_POLICY) --requirepass $(REDIS_PASSWORD)]
+               "redis-server --dir /data --appendonly yes --appendfsync everysec --no-appendfsync-on-rewrite yes --auto-aof-rewrite-percentage 100 --auto-aof-rewrite-min-size $(REDIS_AUTO_AOF_REWRITE_MIN_SIZE) --save '' --maxmemory $(REDIS_MAXMEMORY) --maxmemory-policy $(REDIS_MAXMEMORY_POLICY) --requirepass $(REDIS_PASSWORD)"]
         ports:
           - name: redis
             protocol: TCP


### PR DESCRIPTION
  Closes #926

  ## Summary
The `redis-server` command string in the Kubernetes deployment spec was missing its closing quotation mark before the 
  bracket on line 50 of `kubernetes/15-redis.yml`. This caused a `ruamel.yaml.parser.ParserError` that prevented Malcolm
   from starting in Kubernetes environments.                                                                            
                                            
  ## Fix                                                                                                                
  Add the missing `"` before the closing `]`:                                                                         
                                             
  ```diff                                                                                                               
  - "redis-server ... --requirepass $(REDIS_PASSWORD)]
  + "redis-server ... --requirepass $(REDIS_PASSWORD)"]                                                                 
                                                                                                                        
  Verification
                                                                                                                        
  import yaml                                                                                                         
  # Before fix: ScannerError                                                                                            
  # After fix: parses successfully with 8 args
  with open('kubernetes/15-redis.yml') as f:                                                                            
      yaml.safe_load_all(f)  # no error      