### PR TITLE
ci: SHA-pin 12 third-party GitHub Actions references

### DIFF
--- a/.github/workflows/docker-build-push-scan.yml
+++ b/.github/workflows/docker-build-push-scan.yml
@@ -47,7 +47,7 @@ jobs:
           access_token: ${{ secrets.GITHUB_TOKEN }}
       -
         name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           submodules: 'recursive'
       -
@@ -128,6 +128,6 @@ jobs:
       -
         name: Upload Trivy scan results to GitHub Security tab
         if: ${{ matrix.platform == 'linux/amd64' }}
-        uses: github/codeql-action/upload-sarif@v4
+        uses: github/codeql-action/upload-sarif@9e0d7b8d25671d64c341c19c0152d693099fb5ba # v4.35.5
         with:
           sarif_file: 'trivy-results.sarif'

--- a/.github/workflows/iso-build-push.yml
+++ b/.github/workflows/iso-build-push.yml
@@ -98,7 +98,7 @@ jobs:
           sudo rm -rf /tmp/live-build /tmp/live-build*.deb
       -
         name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       -
         name: Extract branch name
         shell: bash
@@ -166,7 +166,7 @@ jobs:
       -
         name: Upload Trivy scan results to GitHub Security tab
         if: ${{ matrix.platform == 'linux/amd64' }}
-        uses: github/codeql-action/upload-sarif@v4
+        uses: github/codeql-action/upload-sarif@9e0d7b8d25671d64c341c19c0152d693099fb5ba # v4.35.5
         with:
           sarif_file: 'trivy-results.sarif'
       -

--- a/.github/workflows/issues-to-dev-project.yml
+++ b/.github/workflows/issues-to-dev-project.yml
@@ -10,7 +10,7 @@ jobs:
     name: Add issue to project
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/add-to-project@v0.5.0
+      - uses: actions/add-to-project@31b3f3ccdc584546fc445612dec3f38ff5edb41c # v0.5.0
         with:
           project-url: https://github.com/orgs/cisagov/projects/99
           github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}

--- a/.github/workflows/issues-to-training-project.yml
+++ b/.github/workflows/issues-to-training-project.yml
@@ -10,7 +10,7 @@ jobs:
     name: Add issue to project
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/add-to-project@v0.5.0
+      - uses: actions/add-to-project@31b3f3ccdc584546fc445612dec3f38ff5edb41c # v0.5.0
         with:
           project-url: https://github.com/orgs/cisagov/projects/98
           github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}

--- a/.github/workflows/jekyll-gh-pages.yml
+++ b/.github/workflows/jekyll-gh-pages.yml
@@ -32,9 +32,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Setup Pages
-        uses: actions/configure-pages@v6
+        uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
       - name: Replace Umami secrets in _config.yml
         run: |
           sed -i -e "/^umami:/,+2d" ./_config.yml
@@ -42,12 +42,12 @@ jobs:
           echo "  id: '${{ secrets.UMAMI_ID }}'" >> ./_config.yml
           echo "  url: '${{ secrets.UMAMI_URL }}'" >> ./_config.yml
       - name: Build with Jekyll
-        uses: actions/jekyll-build-pages@v1
+        uses: actions/jekyll-build-pages@44a6e6beabd48582f863aeeb6cb2151cc1716697 # v1.0.13
         with:
           source: ./
           destination: ./_site
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v4
+        uses: actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b # v4.0.0
 
   # Deployment job
   deploy:
@@ -59,4 +59,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v5
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0

--- a/.github/workflows/raspi-build-push.yml
+++ b/.github/workflows/raspi-build-push.yml
@@ -108,7 +108,7 @@ jobs:
             zerofree
       -
         name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       -
         name: Extract branch name
         shell: bash


### PR DESCRIPTION
Pins the third-party actions in `.github/workflows/` to immutable commit SHAs, with the resolved release version as an adjacent comment.

## Changes (6 files, 12 references)

- `actions/checkout@v6` to SHA v6.0.2 (4 workflows: docker-build-push-scan, iso-build-push, jekyll-gh-pages, raspi-build-push)
- `github/codeql-action/upload-sarif@v4` to SHA v4.35.5 (docker-build-push-scan, iso-build-push)
- `actions/add-to-project@v0.5.0` to SHA v0.5.0 (issues-to-dev-project, issues-to-training-project)
- `actions/configure-pages@v6`, `actions/deploy-pages@v5`, `actions/jekyll-build-pages@v1`, `actions/upload-pages-artifact@v4` to resolved SHAs (jekyll-gh-pages.yml)

## Why

Same supply-chain motivation as CVE-2025-30066 (the `tj-actions/changed-files` compromise in March). Pinning to commit SHAs anchors the trust boundary at an immutable revision rather than a mutable tag, so a future tag rewrite or breach of the action's repo cannot silently change what runs in this workflow.

YAML validated locally with `yaml.safe_load`.