### PR TITLE
Fix API auth errors and hide NGINX version disclosure

### DIFF
--- a/api/project/__init__.py
+++ b/api/project/__init__.py
@@ -1802,6 +1802,12 @@ def event():
     return jsonify(result=idxResponse)
 
 
+@app.errorhandler(PermissionError)
+def permission_error(e):
+    """Return HTTP 403 for authorization failures."""
+    return jsonify(error="Not authorized to perform this action"), 403
+
+
 @app.errorhandler(Exception)
 def basic_error(e):
     """General exception handler for the app
@@ -1812,10 +1818,10 @@ def basic_error(e):
     Returns
     -------
     error
-        The type of exception and its string representation (e.g., "KeyError: 'protocols'")
+        Generic error message; exception details are logged server-side only.
     """
     errorStr = f"{type(e).__name__}: {str(e)}"
-    if debugApi and (not isinstance(e, PermissionError)):
+    if debugApi:
         print(errorStr)
         print(traceback.format_exc())
-    return jsonify(error=errorStr)
+    return jsonify(error="Internal server error"), 500

--- a/nginx/landingpage/401.html
+++ b/nginx/landingpage/401.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html lang="en">
+    <!-- Copyright (c) 2026 Battelle Energy Alliance, LLC.  All rights reserved. -->
+    <head>
+        <base target="_blank">
+        <meta charset="utf-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
+        <meta name="description" content="" />
+        <meta name="author" content="" />
+        <title>401 Authorization Required</title>
+        <!-- Favicon-->
+        <link rel="icon" type="image/x-icon" href="assets/favicon.ico" />
+        <!-- Bootstrap icons-->
+        <link href="css/bootstrap-icons.css" rel="stylesheet" type="text/css" />
+        <!-- Google fonts-->
+        <link href="css/google-fonts.css" rel="stylesheet" type="text/css" />
+        <!-- Core theme CSS (includes Bootstrap)-->
+        <link href="css/styles.css" rel="stylesheet" />
+    </head>
+    <body>
+        <!-- Navigation-->
+        <nav class="navbar navbar-light bg-light static-top">
+            <div class="container"/>
+        </nav>
+        <!-- Masthead-->
+        <header class="masthead">
+            <div class="container"/>
+        </header>
+        <!-- Icons Grid-->
+        <section class="testimonials bg-light text-center">
+            <div class="container">
+                <h4 class="mb-1">401 Authorization Required</h2>
+                <h2 class="mb-3">Authentication is required to access this resource</h2>
+                <div class="row">
+                <p class="font-weight-light mb-0 fst-italic">Please provide valid credentials and try again.</p>
+                </div>
+            </div>
+        </section>
+        <!-- Bootstrap core JS-->
+        <script src="js/bootstrap.bundle.min.js"></script>
+        <!-- Core theme JS-->
+        <script src="js/scripts.js"></script>
+    </body>
+</html>

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -19,6 +19,7 @@ http {
 
   include /etc/nginx/conf.d/*.conf;
   include /etc/nginx/mime.types;
+  include /etc/nginx/nginx_security_headers.conf;
   sendfile on;
 
   client_max_body_size 20m;
@@ -117,6 +118,7 @@ http {
   server {
     include /etc/nginx/listen_443.conf;
     include /etc/nginx/nginx_ssl_config.conf;
+    include /etc/nginx/nginx_error_pages.conf;
 
     # favicon, logos, banners, etc.
     include /etc/nginx/nginx_image_aliases.conf;
@@ -358,8 +360,6 @@ http {
       root /usr/share/nginx/html;
       index index.html
       try_files $uri $uri/ =404;
-      error_page 404 /404.html;
-      error_page 502 /502.html;
       include /etc/nginx/nginx_proxy_forward_headers.conf;
     }
   }
@@ -368,6 +368,7 @@ http {
   server {
     include /etc/nginx/listen_9200.conf;
     include /etc/nginx/nginx_ssl_config.conf;
+    include /etc/nginx/nginx_error_pages.conf;
 
     # favicon, logos, banners, etc.
     include /etc/nginx/nginx_image_aliases.conf;

--- a/nginx/nginx_error_pages.conf
+++ b/nginx/nginx_error_pages.conf
@@ -1,0 +1,18 @@
+error_page 401 /401.html;
+error_page 404 /404.html;
+error_page 502 /502.html;
+
+location = /401.html {
+  internal;
+  root /usr/share/nginx/html;
+}
+
+location = /404.html {
+  internal;
+  root /usr/share/nginx/html;
+}
+
+location = /502.html {
+  internal;
+  root /usr/share/nginx/html;
+}

--- a/nginx/nginx_readonly.conf
+++ b/nginx/nginx_readonly.conf
@@ -19,6 +19,7 @@ http {
 
   include /etc/nginx/conf.d/*.conf;
   include /etc/nginx/mime.types;
+  include /etc/nginx/nginx_security_headers.conf;
   sendfile on;
 
   client_max_body_size 20m;
@@ -102,6 +103,7 @@ http {
   server {
     include /etc/nginx/listen_443.conf;
     include /etc/nginx/nginx_ssl_config.conf;
+    include /etc/nginx/nginx_error_pages.conf;
 
     # favicon, logos, banners, etc.
     include /etc/nginx/nginx_image_aliases.conf;
@@ -348,8 +350,6 @@ http {
       root /usr/share/nginx/html;
       index index.html
       try_files $uri $uri/ =404;
-      error_page 404 /404.html;
-      error_page 502 /502.html;
       include /etc/nginx/nginx_proxy_forward_headers.conf;
     }
   }

--- a/nginx/nginx_security_headers.conf
+++ b/nginx/nginx_security_headers.conf
@@ -1,0 +1,3 @@
+# Do not disclose NGINX/OpenResty version information in responses.
+server_tokens off;
+more_clear_headers Server;


### PR DESCRIPTION
## Summary
- Return HTTP 403 (instead of 500) for API `PermissionError` failures and avoid leaking exception details in generic error responses.
- Hide OpenResty/NGINX version information from HTTP responses by disabling server tokens and clearing the `Server` header.
- Serve a custom minimal 401 error page without version or copyright footer metadata.

## Test plan
- [ ] Call an API endpoint without sufficient permissions and verify the response is HTTP 403 with a generic message.
- [ ] Request a protected Malcolm URL without credentials and verify the 401 response has no `Server: openresty/...` header and no version string in the HTML body.
- [ ] Rebuild and restart `nginx-proxy`, then confirm 404/502 custom error pages still work.
- [ ] Verify authenticated access to Malcolm UI and OpenSearch API still works as expected.


Made with [Cursor](https://cursor.com)