### PR TITLE
Fix allow TUI configuration to reset variables to empty values

### DIFF
--- a/scripts/installer/actions/shared.py
+++ b/scripts/installer/actions/shared.py
@@ -292,10 +292,14 @@ def _apply_traefik_labels_if_present(data: dict, traefik_tuple) -> None:
 
 
 def _apply_network_overrides(data: dict, network_name: Optional[str]) -> None:
-    if network_name:
+    if network_name is not None:
         for network in deep_get(data, ["networks"], {}):
-            deep_set(data, ["networks", network, "external"], True)
-            deep_set(data, ["networks", network, "name"], network_name)
+            if network_name:
+                deep_set(data, ["networks", network, "external"], True)
+                deep_set(data, ["networks", network, "name"], network_name)
+            else:
+                deep_set(data, ["networks", network, "external"], False)
+                deep_set(data, ["networks", network, "name"], None, deleteIfNone=True)
 
 
 def _get_exposed_services_config(malcolm_config):

--- a/scripts/installer/core/malcolm_config.py
+++ b/scripts/installer/core/malcolm_config.py
@@ -491,12 +491,16 @@ class MalcolmConfig(ObservableStoreMixin):
                 continue
             if isinstance(typed_value, (list, tuple)) and (len(typed_value) == len(env_var_obj.config_items)):
                 for item_key, tv in zip(env_var_obj.config_items, typed_value):
-                    if tv == "" or tv is None:
+                    if (tv == "" or tv is None) and not (
+                        (item := self._items.get(item_key)) and item.accept_blank
+                    ):
                         continue
                     candidates[item_key].append((env_var_obj.key, tv))
             else:
                 for item_key in env_var_obj.config_items:
-                    if typed_value == "" or typed_value is None:
+                    if (typed_value == "" or typed_value is None) and not (
+                        (item := self._items.get(item_key)) and item.accept_blank
+                    ):
                         continue
                     candidates[item_key].append((env_var_obj.key, typed_value))
         return candidates
@@ -545,7 +549,9 @@ class MalcolmConfig(ObservableStoreMixin):
             if len(options) > 1 and winner_env_key is not None:
                 losers = [ek for (ek, _) in options if ek != winner_env_key]
                 InstallerLogger.debug(f"env conflict for {item_key}: picked {winner_env_key} over {losers}")
-            if winner_value is None or winner_value == "":
+            if (winner_value is None or winner_value == "") and not (
+                (item := self._items.get(item_key)) and item.accept_blank
+            ):
                 continue
             try:
                 self.apply_default(item_key, winner_value, ignore_errors=True)
@@ -950,8 +956,8 @@ class MalcolmConfig(ObservableStoreMixin):
         for key, item in self._items.items():
             value = item.get_value()
 
-            # Skip None values and empty strings to avoid validation issues on import
-            if value is None or (isinstance(value, str) and value == ""):
+            # Skip None values and empty strings (for non-accept_blank items) to avoid validation issues on import
+            if value is None or (isinstance(value, str) and value == "" and not item.accept_blank):
                 continue
 
             # Convert Enum values to their string representation for serialization

--- a/scripts/installer/core/malcolm_config.py
+++ b/scripts/installer/core/malcolm_config.py
@@ -491,16 +491,16 @@ class MalcolmConfig(ObservableStoreMixin):
                 continue
             if isinstance(typed_value, (list, tuple)) and (len(typed_value) == len(env_var_obj.config_items)):
                 for item_key, tv in zip(env_var_obj.config_items, typed_value):
-                    if (tv == "" or tv is None) and not (
-                        (item := self._items.get(item_key)) and item.accept_blank
-                    ):
+                    if tv is None:
+                        continue
+                    if tv == "" and not ((item := self._items.get(item_key)) and item.accept_blank):
                         continue
                     candidates[item_key].append((env_var_obj.key, tv))
             else:
                 for item_key in env_var_obj.config_items:
-                    if (typed_value == "" or typed_value is None) and not (
-                        (item := self._items.get(item_key)) and item.accept_blank
-                    ):
+                    if typed_value is None:
+                        continue
+                    if typed_value == "" and not ((item := self._items.get(item_key)) and item.accept_blank):
                         continue
                     candidates[item_key].append((env_var_obj.key, typed_value))
         return candidates
@@ -549,9 +549,9 @@ class MalcolmConfig(ObservableStoreMixin):
             if len(options) > 1 and winner_env_key is not None:
                 losers = [ek for (ek, _) in options if ek != winner_env_key]
                 InstallerLogger.debug(f"env conflict for {item_key}: picked {winner_env_key} over {losers}")
-            if (winner_value is None or winner_value == "") and not (
-                (item := self._items.get(item_key)) and item.accept_blank
-            ):
+            if winner_value is None:
+                continue
+            if winner_value == "" and not ((item := self._items.get(item_key)) and item.accept_blank):
                 continue
             try:
                 self.apply_default(item_key, winner_value, ignore_errors=True)

--- a/scripts/installer/ui/tui/configuration_menu.py
+++ b/scripts/installer/ui/tui/configuration_menu.py
@@ -164,14 +164,13 @@ class ConfigurationMenu(BaseMenu):
         while True:
             new_value = self.prompt_config_item(item_to_edit)
 
-            # If user cancelled or entered same value, stop prompting
-            if new_value is None or new_value == item_to_edit.get_value():
+            # If user cancelled, stop prompting
+            if new_value is None:
                 break
 
             try:
                 # Attempt to set the new value
                 self.malcolm_config.set_value(selected_key, new_value)
-
                 break  # Success - exit the edit loop
             except Exception as e:
                 # Show validation error and re-prompt


### PR DESCRIPTION
# Fix: allow TUI configuration to reset variables to empty values #

## 🗣 Description ##

This PR fixes a systemic issue across the configuration scripts where variables with `accept_blank=True` could not be reset to empty values (`""`) via the TUI. Empty strings were being evaluated as falsy or explicitly skipped in 5 distinct locations across `shared.py`, `malcolm_config.py`, and `configuration_menu.py`.

**Changes Made:**
* **`scripts/installer/actions/shared.py:294-302`** — `_apply_network_overrides` now handles empty strings by setting `external: false` and deleting the name key from networks in `docker-compose.yml`. Changed `if network_name:` to `if network_name is not None:`.
* **`scripts/installer/core/malcolm_config.py:492-502`** — `_build_candidates_from_env` no longer skips empty strings for items with `accept_blank=True` when loading `.env` files.
* **`scripts/installer/core/malcolm_config.py:548-550`** — `_apply_env_candidates` preserves empty string values for `accept_blank` items.
* **`scripts/installer/core/malcolm_config.py:954`** — `to_dict_values_only` now checks `accept_blank` before unconditionally skipping empty strings during config export.
* **`scripts/installer/ui/tui/configuration_menu.py:167-169`** — Removed the equality check that prevented `set_value` from being called when the new value matches the current value, ensuring `is_modified` is set properly (matching DUI behavior).

## 💭 Motivation and context ##

**Fixes #1024**

Without this fix, users are unable to intentionally clear fields like `Container Network Name` during installation or reconfiguration, as the scripts silently fall back to the previously saved state or default values.

## 🧪 Testing ##

* Ran `./scripts/configure.py` locally.
* Verified that setting `Container Network Name` to an empty string successfully clears the value and correctly removes it from `docker-compose.yml`.
* Verified that `.env` files successfully load and export intentional empty string values for `accept_blank` items.