### PR TITLE
Fix filescan recovery when Valkey watch is unavailable

### DIFF
--- a/filescan/python-filescan/bin/filescan_watcher
+++ b/filescan/python-filescan/bin/filescan_watcher
@@ -533,12 +533,15 @@ async def main(
                         'failed to open redis connection for watch',
                         exc_info=True,
                     )
-                    log.error(
-                        'failed to open redis connection for watch: %s:%d/%d',
+                    log.fatal(
+                        'unable to open redis connection for watch: %s:%d/%d',
                         watch.redis.host,
                         watch.redis.port,
                         watch.redis.db,
                     )
+                    # supervisor restarts this process, allowing the watch to recover
+                    # when its configured Valkey endpoint becomes available
+                    sys.exit(1)
 
             elif isinstance(watch, DirectoryWatch):
                 if not watch.path.exists():


### PR DESCRIPTION
## Summary

Fixes `filescan_watcher` startup behaviour when a configured secondary Valkey endpoint is unavailable.

The primary Valkey connection already treats a startup connection failure as fatal and exits. Secondary Redis/Valkey watch connections currently behave differently: a `ConnectionError` is logged, but startup continues without adding that watch to `redis_watch_keys`. Because the watch configuration is only assembled during startup, that watch remains absent for the lifetime of the process even after Valkey becomes available.

This change makes a configured secondary watch connection failure fatal as well. `filescan_watcher` exits with status 1 after logging the endpoint that could not be reached.

The existing Supervisor configuration already runs the watcher with `autorestart=true` and effectively unlimited startup retries, so the process is restarted and re-attempts all configured Valkey connections until they are available.

Fixes #1058

## Behaviour

- Primary Valkey startup behaviour is unchanged.
- A failed configured secondary watch connection no longer leaves the watcher running in a permanently incomplete state.
- The watcher exits nonzero on that startup failure.
- Supervisor restarts it using the existing `autorestart=true` configuration.
- Once the endpoint becomes reachable, normal watch registration proceeds without any new retry loop or background state.

## Scope and validation

- One production file changed: `filescan/python-filescan/bin/filescan_watcher`.
- The patch is limited to the existing `redis.exceptions.ConnectionError` handler for configured watch connections.
- No configuration schema, Redis protocol behaviour, or successful startup path is changed.
- The commit includes the required `Signed-off-by` line.

This follows the issue's proposed fail/restart recovery path and reuses Malcolm's existing Supervisor restart policy rather than introducing a second retry mechanism inside the watcher.