### PR TITLE
Protect ISO installer media when no target disk is available

### DIFF
--- a/malcolm-iso/config/includes.chroot/usr/local/bin/preseed_partman_determine_disk.sh
+++ b/malcolm-iso/config/includes.chroot/usr/local/bin/preseed_partman_determine_disk.sh
@@ -1,3 +1,20 @@
 #!/bin/sh
 
-parted_devices | egrep "^($(find /sys/block -mindepth 1 -maxdepth 1 -type l \( -name '[hs]d*' -o -name 'nvme*' \) -exec ls -l '{}' ';' | grep -v "usb" | sed 's@^.*\([hs]d[a-z]\+\|nvme[0-9]\+\).*$@/dev/\1@' | sed -e :a -e '$!N; s/\n/|/; ta'))" | sort -k2n | head -1 | cut -f1
+NON_USB_DEVICES="$(
+  find /sys/block -mindepth 1 -maxdepth 1 -type l \( -name '[hs]d*' -o -name 'nvme*' \) -exec ls -l '{}' ';' |
+    grep -v "usb" |
+    sed 's@^.*\([hs]d[a-z]\+\|nvme[0-9]\+\).*$@/dev/\1@' |
+    sed -e :a -e '$!N; s/\n/|/; ta'
+)"
+
+if [ -z "$NON_USB_DEVICES" ]; then
+  echo "No non-USB installation target found; refusing to select installer media" >&2
+  echo "/dev/__malcolm_no_install_target__"
+  exit 1
+fi
+
+parted_devices |
+  egrep "^(${NON_USB_DEVICES})" |
+  sort -k2n |
+  head -1 |
+  cut -f1


### PR DESCRIPTION
## Summary

Prevents the Malcolm ISO installer from falling back to its own USB installation media when no non-USB target disk is available.

`preseed_partman_determine_disk.sh` builds a regular expression from non-USB block-device candidates. When that candidate list is empty, the expression becomes `^()`, which matches every line returned by `parted_devices`. The existing sort then chooses the smallest matching disk, which can be the USB device the installer booted from.

This change separates candidate discovery from disk selection and explicitly checks for an empty non-USB candidate set. In that case it reports the error, returns an impossible block-device path and exits nonzero, so the unattended preseed path cannot select or erase the installer media.

The existing prefix matching for valid devices is preserved, including NVMe device names.

Fixes #905

## Scope and validation

- One installer helper script changed.
- Valid non-USB disk selection keeps the existing size-sort and device-prefix behaviour.
- The empty-candidate case no longer constructs an empty matching group.
- The failure path cannot resolve to a real block device.
- The commit includes the required `Signed-off-by` line.