### PR TITLE
Propagate uploaded PCAP tags to filescan events

### DIFF
--- a/filebeat/filebeat-zeek-files-logs.yml
+++ b/filebeat/filebeat-zeek-files-logs.yml
@@ -18,6 +18,8 @@ processors_common: &common_processors
       fields:
         - from: "file"
           to: "_keep_file"
+        - from: "log.file.path"
+          to: "_keep_log_file_path"
       ignore_missing: true
   - drop_fields:
       fields:
@@ -27,6 +29,8 @@ processors_common: &common_processors
       fields:
         - from: "_keep_file"
           to: "file"
+        - from: "_keep_log_file_path"
+          to: "log.file.path"
       ignore_missing: true
   - script:
       lang: javascript

--- a/logstash/pipelines/filescan/11_upload_tags.conf
+++ b/logstash/pipelines/filescan/11_upload_tags.conf
@@ -1,0 +1,31 @@
+# Copyright (c) 2026 Battelle Energy Alliance, LLC.  All rights reserved.
+
+filter {
+
+  # Uploaded-PCAP tags are encoded in the Zeek log symlink filename. The normal
+  # Zeek pipeline extracts these in 1000_zeek_prep.conf; filescan receives the
+  # originating files.log record as metadata, so apply the same pruning rules.
+  if [entity][raw][log][file][path] {
+    ruby {
+      id => "ruby_filescan_zeek_upload_tags"
+      tag_on_exception => "_rubyexception_filescan_zeek_upload_tags"
+      code => "
+        file_name = event.get('[entity][raw][log][file][path]').to_s.split('/').last
+        if match = file_name.match(/^json_streaming_files(?:\((.*)\))?(?:\.\d{4}[_:-]?\d{2}[_:-]?\d{2}[_:-]?\d{2}[_:-]?\d{2}[_:-]?\d{2})?\.log/i) then
+          filename_tags = match.captures.first.to_s.split(',')
+          nbsiteid = filename_tags.find { |str| str[/NBSITEID(.+)/] }[/NBSITEID(.+)/, 1].to_s rescue nil
+          filename_tags.delete_if { |v|
+            v.nil? || v.empty? || (v !~ /\D/) || (v =~ /\A\s*NBSITEID/i) ||
+              (v =~ /\A\s*(pcap|dmp|log|bro|zeek|suricata|m?tcpdump|m?netsniff|autozeek|autosuricata)s?\s*\z/i) ||
+              (v == 'json_streaming_files')
+          }
+          unless filename_tags.empty?
+            event.set('[tags]', (Array(event.get('[tags]')) + filename_tags).compact.uniq)
+          end
+          event.set('[@metadata][nbsiteid]', nbsiteid) unless nbsiteid.nil? || nbsiteid.empty?
+        end
+      "
+    }
+  }
+
+}


### PR DESCRIPTION
## Summary

Makes filescan results inherit the same uploaded-PCAP tags as their originating Zeek events.

Uploaded Zeek archives encode source tags into the generated log symlink filenames. The normal Zeek Logstash pipeline extracts those tags from `log.file.path`, but the dedicated filescan Filebeat pipeline currently drops that path before publishing the files.log record to Valkey. As a result, the raw record retained in filescan metadata has no filename context from which to recover the upload tags.

This change preserves only `log.file.path` alongside the decoded files.log record and adds a small filescan filter that extracts tags from `json_streaming_files(...).log` using the same pruning rules as normal Zeek ingestion. User tags are merged into the filescan event's `tags`, and `NBSITEID` continues to be routed to the existing NetBox-site metadata field.

Fixes #893

## Scope and validation

- `filebeat-zeek-files-logs.yml` preserves one additional metadata field: `log.file.path`.
- A new filescan filter handles tag extraction after the existing filescan parser.
- Numeric/process tags and known transport/log-format tags are pruned consistently with `1000_zeek_prep.conf`.
- Existing event tags are retained and de-duplicated.
- Live files.log paths without encoded tags are unchanged.
- The branch contains one signed-off commit.