### PR TITLE
Handle Zeek time-range rollover filenames

### DIFF
--- a/logstash/pipelines/zeek/1000_zeek_prep.conf
+++ b/logstash/pipelines/zeek/1000_zeek_prep.conf
@@ -9,15 +9,15 @@ filter {
   # - Tags may have been specified, like: conn(tagA,tagB,tagC).log, extract the log type (conn) and the tags (tagA,tagB,tagC).
   # - Normalize log types with - in their names to _ (e.g., opcua-binary -> opcua_binary).
   # - Zeek log files might be caught by filebeat right in the middle of being renamed/moved as
-  #   part of log rotation (ie., renamed from conn.log to conn.2020-01-16-14-00-00.log or
-  #   conn.2020_01_16_14_00_00.log). We don't care about that, ignore the date part and just process
-  #   the log source as we normally would.
+  #   part of log rotation (ie., renamed from conn.log to conn.2020-01-16-14-00-00.log,
+  #   conn.2020_01_16_14_00_00.log, or conn.03:00:00_03:49:27.log). We don't care about that,
+  #   ignore the rotation timestamp and just process the log source as we normally would.
   ruby {
     id => "ruby_zeek_log_source_extract"
     tag_on_exception => "_rubyexception_zeek_log_source_extract"
-    #                                                                       ↓Type     ↓Tags   ↓Rotate Timestamp (discard)                                        ↓.log (discard)
+    #                                                                       ↓Type     ↓Tags   ↓Rotate Timestamp (discard)                                                                                     ↓.log (discard)
     code => "
-      if fileParts = event.get('[log][file][path]').split('/').last.match(/^(.*?)(?:\((.*)\))?(?:\.\d{4}[_:-]?\d{2}[_:-]?\d{2}[_:-]?\d{2}[_:-]?\d{2}[_:-]?\d{2})?\.log/i) then
+      if fileParts = event.get('[log][file][path]').split('/').last.match(/^(.*?)(?:\((.*)\))?(?:\.(?:\d{4}[_:-]?\d{2}[_:-]?\d{2}[_:-]?\d{2}[_:-]?\d{2}[_:-]?\d{2}|\d{2}:\d{2}:\d{2}_\d{2}:\d{2}:\d{2}))?\.log/i) then
         logType, tags  = fileParts.captures
         event.set('[log_source]', logType.gsub('-', '_').gsub(/_general\z/, '')) unless logType.nil?
         event.set('[@metadata][zeek_log_tags]', tags) unless tags.nil?


### PR DESCRIPTION
## Summary

Fixes Zeek log-source detection for rolled-over filenames such as `analyzer.03:00:00_03:49:27.log`. The existing regex only discarded date-based rotation suffixes, so time-range suffixes became part of `log_source`.

The change adds the reported `HH:MM:SS_HH:MM:SS` form while preserving normal, tagged, and date-based filenames.

Fixes #490

## Validation

Tested normal filenames, tagged filenames, both existing date rotation formats, the reported time-range format, and a tagged time-range filename.