### PR TITLE
Stringify unsafe Capa numeric values before indexing

### DIFF
--- a/logstash/pipelines/filescan/98_finalize.conf
+++ b/logstash/pipelines/filescan/98_finalize.conf
@@ -25,6 +25,36 @@ filter {
     base64encode => true
   }
 
+  # Capa match trees can contain integer-like constants beyond JavaScript's safe-integer range.
+  # Preserve those values as strings so OpenSearch Dashboards can deserialize the document even
+  # if an upstream serializer would otherwise emit the value in exponent notation.
+  if [results][strelka][result][scan][capa][rules] {
+    ruby {
+      id => "ruby_filescan_capa_stringify_unsafe_numbers"
+      tag_on_exception => "_rubyexception_filescan_capa_stringify_unsafe_numbers"
+      code => '
+        max_safe_integer = 9_007_199_254_740_991
+        convert = nil
+        convert = lambda do |value|
+          case value
+          when Hash
+            value.each { |key, child| value[key] = convert.call(child) }
+            value
+          when Array
+            value.map! { |child| convert.call(child) }
+          when Numeric
+            value.abs > max_safe_integer ? value.to_s : value
+          else
+            value
+          end
+        end
+
+        rules = event.get("[results][strelka][result][scan][capa][rules]")
+        event.set("[results][strelka][result][scan][capa][rules]", convert.call(rules))
+      '
+    }
+  }
+
   ruby {
       id => "ruby_filescan_move_results_up_and_remove_parent_fields"
       tag_on_exception => "_rubyexception_filescan_move_results_up_and_remove_parent_fields"


### PR DESCRIPTION
## Summary

Prevents OpenSearch Dashboards deserialization failures from very large numeric values inside Strelka Capa match trees. Numeric values outside JavaScript's safe-integer range are converted to decimal strings before indexing.

The conversion is limited to the Capa rules subtree; normal numeric values and the rest of the Strelka payload are unchanged.

Fixes #951

## Validation

Verified the safe-integer boundary, larger positive and negative values, and recursive arrays/hashes.