### PR TITLE
Update macOS Docker Desktop installation guidance

### DIFF
--- a/docs/host-config-macos.md
+++ b/docs/host-config-macos.md
@@ -2,43 +2,47 @@
 
 ## Automatic installation using `install.py`
 
-The `install.py` script will attempt to guide you through the installation of Docker and Docker Compose if they are not present, similar to how it's illustrated in the [**Installation example using Ubuntu 24.04 LTS**](ubuntu-install-example.md#InstallationExample). If that works, skip ahead to **Configure docker daemon option** in this section.
+The `install.py` script will attempt to guide you through the installation of Docker and Docker Compose if they are not present, similar to how it's illustrated in the [**Installation example using Ubuntu 24.04 LTS**](ubuntu-install-example.md#InstallationExample). If that works, skip ahead to **Configure Docker Desktop resources** in this section.
+
+Malcolm can run on both Intel (`x86_64`/`amd64`) and Apple silicon (`AArch64`/`arm64`) Macs using Docker Desktop. Malcolm publishes ARM64 container images, so Apple silicon systems do not need to run the full Malcolm stack through x86 emulation. See [Recommended system requirements](system-requirements.md) for Malcolm's hardware requirements and [Docker's macOS installation documentation](https://docs.docker.com/desktop/setup/install/mac-install/) for the macOS versions currently supported by Docker Desktop.
 
 ## Install Homebrew
 
-The easiest way to install and maintain docker on Mac is using the [Homebrew cask](https://brew.sh). Execute the following in a terminal.
+Homebrew is optional, but it provides a convenient way to install and update Docker Desktop. To install Homebrew, execute the following in a terminal:
 
 ```
 $ /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
-$ brew install cask
 ```
 
+Follow any post-installation instructions printed by Homebrew so the `brew` command is available in your shell.
+
 ## Install Docker Desktop and Docker Compose
+
+Docker Desktop can be installed with Homebrew's Docker Desktop cask:
 
 ```
 $ brew install --cask docker-desktop
 ```
-This will install the latest version of `docker`. It can be upgraded later using `brew` as well:
+
+Start Docker Desktop from the Applications folder and complete its first-run setup. Docker Desktop on macOS includes the Docker Compose plugin, so a separate Compose installation is not required.
+
+Docker Desktop can later be upgraded with:
+
 ```
-$ brew upgrade --cask --no-quarantine docker
+$ brew upgrade --cask docker-desktop
 ```
-You can now run Docker from the Applications folder. Docker Desktop on macOS also includes the Docker Compose plugin.
 
-## Configure docker daemon option
+On Apple silicon, Docker recommends installing Rosetta 2 for the best compatibility with optional tools that still require `amd64` emulation. Malcolm itself has ARM64 container images, so Rosetta is not required merely to run Malcolm's native ARM64 images.
 
-Some changes should be made for performance. See the following (unaffiliated) posts/articles for more information:
+## Configure Docker Desktop resources
 
-* [What Are the Latest Docker Desktop Enterprise-Grade Performance Optimizations?](https://www.docker.com/blog/what-are-the-latest-docker-desktop-enterprise-grade-performance-optimizations/)
-* [Docker on macOS is still slow?](https://www.paolomainardi.com/posts/docker-performance-macos-2025)
-* [Docker on macOS is slow and how to fix it](https://www.cncf.io/blog/2023/02/02/docker-on-macos-is-slow-and-how-to-fix-it)
-* [The most performant Docker setup on macOS](https://medium.com/@guillem.riera/the-most-performant-docker-setup-on-macos-apple-silicon-m1-m2-m3-for-x64-amd64-compatibility-da5100e2557d)
-* [Why Docker Compose Is Actually Killing Your M1 Mac](https://medium.com/%40sohail_saifi/why-docker-compose-is-actually-killing-your-m1-mac-the-performance-truth-no-one-talks-about-4357678c8584)
+Malcolm is resource intensive. Review [Recommended system requirements](system-requirements.md) before configuring Docker Desktop. Malcolm requires at least 8 CPU cores and 24 GB of RAM for a dedicated system, while 16 or more CPU cores and 32 GB or more of RAM are recommended for an optimal experience.
 
-* **Resource allocation** - For best results, Mac users should be running recent system with at least 32GB RAM and an SSD. In the system tray, select **Docker** → **Preferences** → **Advanced**. Set the resources available to Docker to at least 6 CPUs and at least 24GB RAM (even more is preferable).
+Open Docker Desktop **Settings** → **Resources** → **Advanced** and allocate enough CPU, memory, and disk space to the Docker Linux VM for the Malcolm workload while leaving sufficient resources for macOS itself. Docker Desktop defaults to using 50% of the host's memory, which may be too low for Malcolm on some systems.
 
-* **Volume mount performance** - Users can speed up performance of volume mounts by removing unused paths from **Docker** → **Preferences** → **File Sharing**. For example, if volumes are mounted under the home directory only, users could share /Users but remove other paths.
+For file sharing performance, Docker Desktop currently uses VirtioFS by default on macOS. Keep Malcolm under a directory that Docker Desktop is allowed to share. If needed, manage shared paths under **Settings** → **Resources** → **File sharing**. Sharing only the directories required by Malcolm can reduce unnecessary file-system overhead.
 
-After making these changes, right-click on the Docker 🐋 icon in the system tray and select **Restart**.
+After changing Docker Desktop resource or file-sharing settings, restart Docker Desktop before starting Malcolm.
 
 ## Podman
 


### PR DESCRIPTION
## Summary

Refreshes Malcolm's macOS host-setup documentation for current Homebrew and Docker Desktop usage.

Changes include:
- removes the obsolete `brew install cask` step
- uses the current `docker-desktop` Homebrew cask consistently for install and upgrade
- documents current Apple silicon/ARM64 support
- updates Docker Desktop resource and file-sharing navigation
- aligns resource guidance with Malcolm's current system requirements

Fixes #405

## Validation

Checked the commands and settings against current Homebrew and Docker Desktop documentation and Malcolm's current ARM64/release documentation.