### PR TITLE
Honor uppercase proxy variables for Arkime GeoIP updates

### DIFF
--- a/arkime/scripts/initarkime.sh
+++ b/arkime/scripts/initarkime.sh
@@ -37,6 +37,13 @@ fi
 
 if [[ "$MALCOLM_PROFILE" == "malcolm" ]]; then
 
+  # curl and tools called by Arkime's updater may expect lowercase proxy variables.
+  # Preserve explicitly configured lowercase values, otherwise mirror the common
+  # uppercase container environment variables.
+  [[ -n "${HTTP_PROXY:-}" && -z "${http_proxy:-}" ]] && export http_proxy="$HTTP_PROXY"
+  [[ -n "${HTTPS_PROXY:-}" && -z "${https_proxy:-}" ]] && export https_proxy="$HTTPS_PROXY"
+  [[ -n "${NO_PROXY:-}" && -z "${no_proxy:-}" ]] && export no_proxy="$NO_PROXY"
+
   # download and/or update geo updates
   $ARKIME_DIR/bin/arkime_update_geo.sh
 


### PR DESCRIPTION
## Summary

Makes Arkime's GeoIP startup update honor common uppercase container proxy variables.

Before invoking `arkime_update_geo.sh`, `HTTP_PROXY`, `HTTPS_PROXY` and `NO_PROXY` are mirrored to their lowercase forms only when the lowercase variables are not already set. This preserves explicit lowercase configuration while supporting deployments that provide the conventional uppercase container variables.

Refs #482

## Validation

Checked behavior for uppercase-only, lowercase-only, mixed and unset proxy environments. Existing lowercase values remain authoritative.