### PR TITLE
Enforce extraction byte limit for raw streams

### DIFF
--- a/scripts/safe-extract.py
+++ b/scripts/safe-extract.py
@@ -59,20 +59,41 @@ def _strip_compression_ext(path):
     )
 
 
+def _copy_limited_stream(src, dst):
+    total_bytes = 0
+    while chunk := src.read(65536):
+        total_bytes += len(chunk)
+        if total_bytes > ARCHIVE_EXTRACT_MAX_TOTAL_BYTES:
+            raise ArchiveBombError(
+                f"archive exceeds size limit ({ARCHIVE_EXTRACT_MAX_TOTAL_BYTES} bytes): "
+                f"stopped after {total_bytes} decompressed bytes"
+            )
+        dst.write(chunk)
+
+
 def _extract_raw_stream(archive, dest, archive_mime=None):
     open_fn = ARCHIVE_RAW_STREAM_MIMES[archive_mime if archive_mime else magic.from_file(archive, mime=True)]
     outname = _strip_compression_ext(archive)
     outpath = os.path.join(dest, outname)
     with open_fn(archive, 'rb') as src, open(outpath, 'wb') as dst:
-        while chunk := src.read(65536):
-            dst.write(chunk)
+        _copy_limited_stream(src, dst)
 
 
 def _extract_lzip(archive, dest):
     outname = _strip_compression_ext(archive)
     outpath = os.path.join(dest, outname)
-    with open(outpath, 'wb') as dst:
-        subprocess.run(['lzip', '-d', '-c', archive], stdout=dst, check=True)
+    process = subprocess.Popen(['lzip', '-d', '-c', archive], stdout=subprocess.PIPE)
+    try:
+        with open(outpath, 'wb') as dst:
+            _copy_limited_stream(process.stdout, dst)
+        returncode = process.wait()
+        if returncode != 0:
+            raise subprocess.CalledProcessError(returncode, process.args)
+    except Exception:
+        if process.poll() is None:
+            process.kill()
+        process.wait()
+        raise
 
 
 def _extract_libarchive(archive, dest):
@@ -131,14 +152,18 @@ def safe_extract(archive, dest):
     os.makedirs(dest, exist_ok=False)
     file_mime_type = magic.from_file(archive, mime=True)
 
-    if TAR_COMPRESSED_EXTS.search(archive):
-        _extract_libarchive(archive, dest)
-    elif file_mime_type in ARCHIVE_RAW_STREAM_MIMES:
-        _extract_raw_stream(archive, dest, file_mime_type)
-    elif file_mime_type == 'application/x-lzip':
-        _extract_lzip(archive, dest)
-    else:
-        _extract_libarchive(archive, dest)
+    try:
+        if TAR_COMPRESSED_EXTS.search(archive):
+            _extract_libarchive(archive, dest)
+        elif file_mime_type in ARCHIVE_RAW_STREAM_MIMES:
+            _extract_raw_stream(archive, dest, file_mime_type)
+        elif file_mime_type == 'application/x-lzip':
+            _extract_lzip(archive, dest)
+        else:
+            _extract_libarchive(archive, dest)
+    except ArchiveBombError:
+        shutil.rmtree(dest, ignore_errors=True)
+        raise
 
 
 if len(sys.argv) != 3:


### PR DESCRIPTION
## Summary

Extends `SAFE_EXTRACT_MAX_BYTES` enforcement to raw single-stream compression formats handled by `safe-extract.py`.

The libarchive path already checks cumulative uncompressed bytes, but gzip, bzip2, xz/lzma and lzip streams could previously write their full decompressed output without applying the configured extraction byte limit.

This change:

* centralizes size-limited stream copying
* applies the byte cap to gzip, bzip2 and xz/lzma streams
* streams lzip output through the same limit instead of writing it directly
* terminates lzip processing when extraction fails or the limit is exceeded
* removes the extraction destination after an `ArchiveBombError`

## Validation

Exercised gzip, bzip2 and xz payloads with a deliberately small decompressed-byte limit and confirmed oversized streams are rejected.

Reviewed the resulting diff to confirm the change is limited to `scripts/safe-extract.py`.

The commit includes the required `Signed-off-by` line.
