### PR TITLE
Make Suricata rule update schedule configurable

### DIFF
--- a/config/suricata.env.example
+++ b/config/suricata.env.example
@@ -3,6 +3,8 @@ SURICATA_CUSTOM_RULES_ONLY=false
 SURICATA_UPDATE_RULES=false
 SURICATA_UPDATE_DEBUG=false
 SURICATA_UPDATE_ETOPEN=true
+# Five-field cron expression controlling when the Suricata rule update job runs
+SURICATA_UPDATE_CRON_EXPRESSION=0 0 * * *
 SURICATA_DISABLE_ICS_ALL=false
 SURICATA_DISABLE_SIDS=
 # suricata_config_populate.py can use MANY more environment variables to tweak

--- a/config/suricata.env.example
+++ b/config/suricata.env.example
@@ -4,7 +4,7 @@ SURICATA_UPDATE_RULES=false
 SURICATA_UPDATE_DEBUG=false
 SURICATA_UPDATE_ETOPEN=true
 # Five-field cron expression controlling when the Suricata rule update job runs
-SURICATA_UPDATE_CRON_EXPRESSION=0 0 * * *
+SURICATA_UPDATE_CRON_EXPRESSION='0 0 * * *'
 SURICATA_DISABLE_ICS_ALL=false
 SURICATA_DISABLE_SIDS=
 # suricata_config_populate.py can use MANY more environment variables to tweak

--- a/suricata/scripts/docker_entrypoint.sh
+++ b/suricata/scripts/docker_entrypoint.sh
@@ -46,5 +46,18 @@ if [[ -d "$CONFIG_DIR" ]] && [[ -f "$CONFIG_DIR"/"$SURICATA_SOCKET_TEMPLATE_FILE
   done
 fi
 
+# Configure Suricata rule update scheduling at container startup so deployments can change
+# the schedule through suricata.env without rebuilding the image. Supercronic expects the
+# standard five-field cron format used by Malcolm's existing midnight-daily schedule.
+SURICATA_UPDATE_CRON_EXPRESSION="${SURICATA_UPDATE_CRON_EXPRESSION:-0 0 * * *}"
+read -r -a SURICATA_UPDATE_CRON_FIELDS <<< "$SURICATA_UPDATE_CRON_EXPRESSION"
+if [[ ${#SURICATA_UPDATE_CRON_FIELDS[@]} -ne 5 ]]; then
+    echo "Invalid SURICATA_UPDATE_CRON_EXPRESSION '$SURICATA_UPDATE_CRON_EXPRESSION'; using '0 0 * * *'" >&2
+    SURICATA_UPDATE_CRON_EXPRESSION="0 0 * * *"
+fi
+if [[ -n "${SUPERCRONIC_CRONTAB:-}" ]]; then
+    printf '%s %s\n' "$SURICATA_UPDATE_CRON_EXPRESSION" "/bin/bash /usr/local/bin/suricata-update-rules.sh" > "$SUPERCRONIC_CRONTAB"
+fi
+
 # start supervisor (which will spawn pcap-suricata, cron, etc.) or whatever the default command is
 exec "$@"


### PR DESCRIPTION
## Summary

Makes the periodic Suricata rule-update schedule configurable through `SURICATA_UPDATE_CRON_EXPRESSION`.

The existing midnight-daily schedule remains the default, but deployments can override it through `suricata.env` without rebuilding the image. Invalid cron field counts fall back to the existing default.

Refs #723

## Validation

Default behavior is preserved. Custom five-field schedules are written at container startup. Changes are limited to `suricata/scripts/docker_entrypoint.sh` and `config/suricata.env.example`. All commits include Signed-off-by.