### PR TITLE
Update Suricata rules at container startup

### DIFF
--- a/suricata/scripts/docker_entrypoint.sh
+++ b/suricata/scripts/docker_entrypoint.sh
@@ -8,6 +8,7 @@ setcap 'CAP_NET_RAW+eip CAP_NET_ADMIN+eip CAP_IPC_LOCK+eip' /usr/bin/suricata ||
 
 # - modify suricata.yaml according to environment variables (as non-root)
 # - if SURICATA_DISABLE_SIDS contains entries for disable.conf, write it and run suricata-update to apply
+# - if periodic rule updates are enabled, perform the first update immediately at startup
 if [[ "$(id -u)" == "0" ]] && [[ -n "$PUSER" ]]; then
     su -s /bin/bash -p ${PUSER} << 'EOF'
         /usr/local/bin/suricata_config_populate.py --suricata ${SURICATA_TEST_CONFIG_BIN} ${SURICATA_TEST_CONFIG_VERBOSITY:-} >&2
@@ -16,7 +17,13 @@ if [[ "$(id -u)" == "0" ]] && [[ -n "$PUSER" ]]; then
                 while IFS= read -r line; do
                     grep -qxF "$line" /etc/suricata/disable.conf 2>/dev/null || echo "$line"
                 done >> /etc/suricata/disable.conf
-            SURICATA_UPDATE_RULES=true SURICATA_UPDATE_SOURCES=false SURICATA_UPDATE_ETOPEN=false /usr/local/bin/suricata-update-rules.sh
+            if [[ "${SURICATA_UPDATE_RULES:-false}" == "true" ]]; then
+                /usr/local/bin/suricata-update-rules.sh
+            else
+                SURICATA_UPDATE_RULES=true SURICATA_UPDATE_SOURCES=false SURICATA_UPDATE_ETOPEN=false /usr/local/bin/suricata-update-rules.sh
+            fi
+        elif [[ "${SURICATA_UPDATE_RULES:-false}" == "true" ]]; then
+            /usr/local/bin/suricata-update-rules.sh
         fi
 EOF
 else
@@ -26,7 +33,13 @@ else
             while IFS= read -r line; do
                 grep -qxF "$line" /etc/suricata/disable.conf 2>/dev/null || echo "$line"
             done >> /etc/suricata/disable.conf
-        SURICATA_UPDATE_RULES=true SURICATA_UPDATE_SOURCES=false SURICATA_UPDATE_ETOPEN=false /usr/local/bin/suricata-update-rules.sh
+        if [[ "${SURICATA_UPDATE_RULES:-false}" == "true" ]]; then
+            /usr/local/bin/suricata-update-rules.sh
+        else
+            SURICATA_UPDATE_RULES=true SURICATA_UPDATE_SOURCES=false SURICATA_UPDATE_ETOPEN=false /usr/local/bin/suricata-update-rules.sh
+        fi
+    elif [[ "${SURICATA_UPDATE_RULES:-false}" == "true" ]]; then
+        /usr/local/bin/suricata-update-rules.sh
     fi
 fi
 


### PR DESCRIPTION
## Summary

Runs the configured Suricata rule update once during container startup when `SURICATA_UPDATE_RULES=true`, so a newly started container does not wait for the periodic cron run. The existing local-only `SURICATA_DISABLE_SIDS` path is preserved when normal updates are disabled.

Refs #723

## Validation

`bash -n` passes. Disabled updates still perform no startup update without disable SIDs. Enabled updates run once before Supervisor. The change is limited to `suricata/scripts/docker_entrypoint.sh`. The commit includes Signed-off-by.