### PR TITLE
Allow enabling indexed Suricata rule sources

### DIFF
--- a/config/suricata.env.example
+++ b/config/suricata.env.example
@@ -3,6 +3,9 @@ SURICATA_CUSTOM_RULES_ONLY=false
 SURICATA_UPDATE_RULES=false
 SURICATA_UPDATE_DEBUG=false
 SURICATA_UPDATE_ETOPEN=true
+# Comma-separated suricata-update indexed sources to enable. Optional source parameters
+# may follow the source name separated by '|', e.g. 'ptresearch/attackdetection,et/pro|secret-code=REDACTED'.
+SURICATA_UPDATE_ENABLE_SOURCES=
 SURICATA_DISABLE_ICS_ALL=false
 SURICATA_DISABLE_SIDS=
 # suricata_config_populate.py can use MANY more environment variables to tweak

--- a/suricata/scripts/suricata-update-rules.sh
+++ b/suricata/scripts/suricata-update-rules.sh
@@ -35,6 +35,38 @@ if type suricata-update >/dev/null 2>&1; then
       --config "${SURICATA_UPDATE_CONFIG_FILE:-/etc/suricata/update.yaml}" \
       --suricata-conf "${SURICATA_CONFIG_FILE:-/etc/suricata/suricata.yaml}" 2>&1
 
+  # Enable indexed rule sources requested through the environment. Source specs are
+  # comma-separated; optional source parameters are separated from the source name
+  # with '|', for example: et/pro|secret-code=example.
+  if [[ -n "${SURICATA_UPDATE_ENABLE_SOURCES:-}" ]]; then
+    IFS=',' read -r -a SOURCE_SPECS <<< "${SURICATA_UPDATE_ENABLE_SOURCES}"
+    for SOURCE_SPEC in "${SOURCE_SPECS[@]}"; do
+      IFS='|' read -r -a SOURCE_PARTS <<< "${SOURCE_SPEC}"
+      SOURCE_NAME="${SOURCE_PARTS[0]}"
+      SOURCE_NAME="${SOURCE_NAME#"${SOURCE_NAME%%[![:space:]]*}"}"
+      SOURCE_NAME="${SOURCE_NAME%"${SOURCE_NAME##*[![:space:]]}"}"
+      [[ -n "${SOURCE_NAME}" ]] || continue
+
+      SOURCE_PARAMS=()
+      if [[ ${#SOURCE_PARTS[@]} -gt 1 ]]; then
+        for SOURCE_PARAM in "${SOURCE_PARTS[@]:1}"; do
+          SOURCE_PARAM="${SOURCE_PARAM#"${SOURCE_PARAM%%[![:space:]]*}"}"
+          SOURCE_PARAM="${SOURCE_PARAM%"${SOURCE_PARAM##*[![:space:]]}"}"
+          [[ -n "${SOURCE_PARAM}" ]] && SOURCE_PARAMS+=("${SOURCE_PARAM}")
+        done
+      fi
+
+      suricata-update enable-source \
+        "${SOURCE_NAME}" \
+        "${SOURCE_PARAMS[@]}" \
+        $DEBUG_FLAG \
+        --suricata /usr/bin/suricata-offline \
+        --data-dir "${SURICATA_MANAGED_DIR:-/var/lib/suricata}" \
+        --config "${SURICATA_UPDATE_CONFIG_FILE:-/etc/suricata/update.yaml}" \
+        --suricata-conf "${SURICATA_CONFIG_FILE:-/etc/suricata/suricata.yaml}" 2>&1
+    done
+  fi
+
   suricata-update update \
     $DEBUG_FLAG \
     $ETOPEN_FLAG \


### PR DESCRIPTION
## Summary

Adds `SURICATA_UPDATE_ENABLE_SOURCES` for enabling indexed `suricata-update` rule sources from environment configuration. It supports comma-separated source specs and optional `|`-separated parameters, for example `ptresearch/attackdetection,et/pro|secret-code=REDACTED`, without using `eval`.

Existing source-refresh and rule-update behavior is unchanged when the new variable is unset.

Refs #723

## Validation

An empty value leaves current behavior unchanged. Source specs are parsed into argument arrays and whitespace is trimmed. Changes are limited to `suricata/scripts/suricata-update-rules.sh` and `config/suricata.env.example`. All commits include Signed-off-by.