### PR TITLE
Preserve explicit settings loaded from env files

### DIFF
--- a/scripts/installer/core/malcolm_config.py
+++ b/scripts/installer/core/malcolm_config.py
@@ -554,7 +554,13 @@ class MalcolmConfig(ObservableStoreMixin):
             if winner_value == "" and not ((item := self._items.get(item_key)) and item.accept_blank):
                 continue
             try:
-                self.apply_default(item_key, winner_value, ignore_errors=True)
+                # Values read from persisted .env files are explicit configuration, not
+                # computed defaults. Mark the ConfigItem modified so value dependencies
+                # respect it, but keep it out of the current-session change summary.
+                was_session_modified = item_key in self._modified_keys
+                self.set_value(item_key, winner_value, ignore_errors=True)
+                if not was_session_modified and item_key in self._modified_keys:
+                    self._modified_keys.remove(item_key)
             except (ConfigItemNotFoundError, ConfigValueValidationError) as e:
                 if "unittest" not in sys.modules:
                     InstallerLogger.warning(f"Could not set config for {item_key} from env: {e}")

--- a/scripts/installer/tests/unit/test_env_file_import_existing.py
+++ b/scripts/installer/tests/unit/test_env_file_import_existing.py
@@ -57,6 +57,15 @@ class TestEnvFileImportExisting(unittest.TestCase):
         # "false" for MANAGE_PCAP_FILES translates to False boolean
         self.assertFalse(cfg.get_value(KEY_CONFIG_ITEM_ARKIME_MANAGE_PCAP))
 
+        # Persisted values are explicit user configuration. They should be protected from
+        # dependency defaults, but loading them must not make the configuration summary
+        # report them as changes made during the current session.
+        self.assertTrue(cfg.get_item(KEY_CONFIG_ITEM_AUTO_FREQ).is_modified)
+        self.assertTrue(cfg.get_item(KEY_CONFIG_ITEM_ARKIME_MANAGE_PCAP).is_modified)
+        session_changes = cfg.get_all_config_items(modified_only=True)
+        self.assertNotIn(KEY_CONFIG_ITEM_AUTO_FREQ, session_changes)
+        self.assertNotIn(KEY_CONFIG_ITEM_ARKIME_MANAGE_PCAP, session_changes)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

Treats values loaded from existing `.env` files as explicit configuration rather than computed defaults.

`ConfigItem.set_value()` intentionally marks a value as modified so dependency rules with `only_if_unmodified=True` do not overwrite it. Environment loading previously used `apply_default()`, leaving persisted user settings unmodified and therefore eligible for dependency-driven replacement.

This change loads persisted values through `set_value()` so dependency rules respect them, while removing those keys from the current-session modification list so the configuration summary does not report every loaded setting as a new change.

Refs #949

## Validation

Added regression coverage to confirm that values loaded from existing environment files:

- retain their persisted values
- are marked modified at the `ConfigItem` level
- are not reported as changes made during the current configuration session

The production change is limited to `_apply_env_candidates()` in `scripts/installer/core/malcolm_config.py`.

Both commits include the required `Signed-off-by` line.