### PR TITLE
Expose the default OpenSearch dashboard setting

### DIFF
--- a/config/dashboards-helper.env.example
+++ b/config/dashboards-helper.env.example
@@ -3,6 +3,12 @@ DASHBOARDS_DARKMODE=true
 # default "from" and "to" values for the OpenSearch Dashboards query time frame picker
 DASHBOARDS_TIMEPICKER_FROM=now-24h
 DASHBOARDS_TIMEPICKER_TO=now
+# Dashboard to open by default. Common Malcolm dashboard IDs:
+#   Overview:                 0ad3d7c2-3441-485e-9dfe-dbb22e84e576
+#   Security Overview:        95479950-41f2-11ea-88fa-7151df485405
+#   ICS/IoT Security Overview: 4a4bde20-4760-11ea-949c-bbb5a9feecbf
+#   Severity:                 d2dd0180-06b1-11ec-8c6b-353266ade330
+OPENSEARCH_DEFAULT_DASHBOARD=0ad3d7c2-3441-485e-9dfe-dbb22e84e576
 # A prefix to prepend to the titles of imported Malcolm dashboards
 DASHBOARDS_PREFIX=
 # The base URL of the Malcolm instance (e.g., https://malcolm.home.arpa), only used


### PR DESCRIPTION
## Summary

Adds `OPENSEARCH_DEFAULT_DASHBOARD` to the standard `dashboards-helper.env` configuration template.

Malcolm already honors this variable when creating the Dashboards advanced setting, but it was not exposed in the normal configuration file. The template now documents the IDs for the four candidate landing dashboards identified in #465:

- Overview
- Security Overview
- ICS/IoT Security Overview
- Severity

Overview remains the default, so existing behavior is unchanged.

Refs #465

## Validation

Confirmed `dashboards/scripts/shared-object-creation.sh` already reads `OPENSEARCH_DEFAULT_DASHBOARD` and falls back to the same Overview dashboard ID used here.

The branch changes only `config/dashboards-helper.env.example`.

The commit includes the required `Signed-off-by` line.