### PR TITLE
Expose the Suricata source refresh toggle

### DIFF
--- a/config/suricata.env.example
+++ b/config/suricata.env.example
@@ -1,6 +1,8 @@
 # Whether or not the default Suricata ruleset will be ignored and only custom rules used
 SURICATA_CUSTOM_RULES_ONLY=false
 SURICATA_UPDATE_RULES=false
+# Whether or not to refresh the suricata-update source index before updating rules
+SURICATA_UPDATE_SOURCES=true
 SURICATA_UPDATE_DEBUG=false
 SURICATA_UPDATE_ETOPEN=true
 SURICATA_DISABLE_ICS_ALL=false


### PR DESCRIPTION
## Summary

Adds `SURICATA_UPDATE_SOURCES` to the standard Suricata environment configuration.

`suricata-update-rules.sh` already supports this variable and defaults it to `true`, but users could not see or configure it in `config/suricata.env`. Exposing it makes source-index refresh behavior configurable without changing the current default.

Refs #723

## Validation

Confirmed `suricata/scripts/suricata-update-rules.sh` checks `SURICATA_UPDATE_SOURCES` before running `suricata-update update-sources`.

The default remains `true`, so existing behavior is unchanged.

The branch changes only `config/suricata.env.example`.

The commit includes the required `Signed-off-by` line.