### PR TITLE
Fix unknown service cleanup in Zeek IANA generator

### DIFF
--- a/zeek/scripts/zeek_iana_lookup_generator.py
+++ b/zeek/scripts/zeek_iana_lookup_generator.py
@@ -100,7 +100,7 @@ def processCsv(inputFileName, outputFileName):
                         note,
                         flags=re.IGNORECASE,
                     )
-                    name = '' if name.lower() == 'unknown' else name
+                    service = '' if service.lower() == 'unknown' else service
 
                     if (
                         proto


### PR DESCRIPTION
## Summary
Correct the service-name normalization in `zeek_iana_lookup_generator.py`.

The existing code checks the source-loop variable `name` for the literal value `unknown`, but that variable contains the matched source name (`iana` or `drahgkar`). As a result, a service value of `unknown` is never cleared as intended.

Change the normalization to update `service` instead. This keeps generated Zeek service tables from emitting `unknown` as a service name when the source dataset uses that sentinel.