### PR TITLE
Fix DHCP NetBox autopopulation source field

### DIFF
--- a/logstash/pipelines/enrichment/21_netbox.conf
+++ b/logstash/pipelines/enrichment/21_netbox.conf
@@ -176,7 +176,7 @@ filter {
           path => "/usr/share/logstash/malcolm-ruby/netbox_enrich.rb"
           script_params => {
             "lookup_type" => "ip_device"
-            "source" => "[zeek][dhcp][assigned_addr]"
+            "source" => "[zeek][dhcp][assigned_ip]"
             "source_hostname" => "[zeek][dhcp][client_fqdn]"
             "add_tag" => "netbox"
             "enabled_env" => "NETBOX_ENRICHMENT"
@@ -203,7 +203,7 @@ filter {
           path => "/usr/share/logstash/malcolm-ruby/netbox_enrich.rb"
           script_params => {
             "lookup_type" => "ip_device"
-            "source" => "[zeek][dhcp][assigned_addr]"
+            "source" => "[zeek][dhcp][assigned_ip]"
             "source_hostname" => "[zeek][dhcp][host_name]"
             "add_tag" => "netbox"
             "enabled_env" => "NETBOX_ENRICHMENT"
@@ -411,4 +411,3 @@ filter {
   } # netbox in tags
 
 } # filter
-


### PR DESCRIPTION
## Summary
Use the normalized Zeek DHCP `assigned_ip` field for NetBox hostname autopopulation.

## Problem
The Zeek DHCP parser normalizes `assigned_addr` to `[zeek][dhcp][assigned_ip]`, and this enrichment block already checks `assigned_ip`. However, both DHCP hostname filters still pass `[zeek][dhcp][assigned_addr]` as their source, so the IP value is missing when those filters run.

## Change
Use `[zeek][dhcp][assigned_ip]` for both the client FQDN and host-name NetBox autopopulation paths.

This aligns the enrichment lookup with the field produced by the DHCP normalization pipeline.