### PR TITLE
Handle incomplete rows in Zeek IANA generator

### DIFF
--- a/zeek/scripts/zeek_iana_lookup_generator.py
+++ b/zeek/scripts/zeek_iana_lookup_generator.py
@@ -75,6 +75,7 @@ def processCsv(inputFileName, outputFileName):
             with open(outputFileName, 'w') as outfile:
                 outfile.write("#fields\tproto\tdport\tname\tdescription\n")
                 for row in reader:
+                    proto, port, service, note = '', '', '', ''
                     match matchedKnownSource:
                         case 'drahgkar':
                             if (row.get('Protocol', '?') != '?') and row.get('Port', None):


### PR DESCRIPTION
## Summary

Prevent incomplete rows from the Drahgkar ports-and-protocols source from reusing values from a previous row or raising `UnboundLocalError`.

## Problem

For the Drahgkar input format, `proto`, `port`, `service` and `note` are assigned only when both the protocol and port fields are usable. The code continues processing the row either way.

That means an incomplete row can:
- reference the variables before they have been assigned, if it appears first; or
- retain values from the previous valid row.

## Change

Initialise the four normalised row values to empty strings at the start of each iteration. Valid Drahgkar and IANA rows then overwrite them normally; incomplete rows fail the existing eligibility checks and are skipped.

The output format and handling of valid rows are unchanged.