### PR TITLE
Fix storage configuration item declaration

### DIFF
--- a/scripts/installer/configs/configuration_items/storage.py
+++ b/scripts/installer/configs/configuration_items/storage.py
@@ -48,7 +48,7 @@ CONFIG_ITEM_CLEAN_UP_OLD_ARTIFACTS = ConfigItem(
     widget_type=WidgetType.CHECKBOX,
 )
 
-KEY_CONFIG_ITEM_CLEAN_UP_OLD_INDICES = ConfigItem(
+CONFIG_ITEM_CLEAN_UP_OLD_INDICES = ConfigItem(
     key=KEY_CONFIG_ITEM_CLEAN_UP_OLD_INDICES,
     label="Delete Old Indices",
     default_value=False,
@@ -185,7 +185,7 @@ CONFIG_ITEM_INDEX_MANAGEMENT_POLICY = ConfigItem(
     label="Enable Arkime Index Management",
     default_value=False,
     validator=lambda x: isinstance(x, bool),
-    question="Enable index management policies (ILM/ISM) in Arkime? (see https://https://arkime.com/faq#ilm)",
+    question="Enable index management policies (ILM/ISM) in Arkime? (see https://arkime.com/faq#ilm)",
     widget_type=WidgetType.CHECKBOX,
 )
 


### PR DESCRIPTION
## Summary

Correct two small issues in the installer storage configuration.

- Keep `KEY_CONFIG_ITEM_CLEAN_UP_OLD_INDICES` as the imported key constant and assign its `ConfigItem` to the expected `CONFIG_ITEM_CLEAN_UP_OLD_INDICES` name.
- Fix the duplicated `https://` in the Arkime ILM help link.

The first change avoids shadowing the configuration key constant at module scope. The configuration key and default behaviour are unchanged.