### PR TITLE
Handle qualified NetBox PluginConfig bases

### DIFF
--- a/netbox/control-scripts/netbox_install_plugins.py
+++ b/netbox/control-scripts/netbox_install_plugins.py
@@ -308,7 +308,11 @@ def install_plugins(args):
                         # look at each Class defined in this code
                         for c in [n for n in node.body if isinstance(n, ast.ClassDef)]:
                             # plugins are classes with "PluginConfig" for a parent
-                            if any([baseClass.id == 'PluginConfig' for baseClass in c.bases]):
+                            if any(
+                                (isinstance(baseClass, ast.Name) and baseClass.id == 'PluginConfig')
+                                or (isinstance(baseClass, ast.Attribute) and baseClass.attr == 'PluginConfig')
+                                for baseClass in c.bases
+                            ):
                                 # this ia a plugin class, so iterate over its members (functions,
                                 #   variables, etc.) to find its name
                                 for item in c.body:


### PR DESCRIPTION
## Summary

Make NetBox plugin class discovery handle more than bare `PluginConfig` base names.

The current AST check reads `.id` from every base class node. That attribute only exists on `ast.Name`; a qualified base such as `netbox.plugins.PluginConfig` is an `ast.Attribute` and causes plugin discovery for the file to fall into the exception handler.

This change checks the AST node type before reading the identifier and recognises both bare and qualified `PluginConfig` bases. Existing direct `PluginConfig` declarations are unchanged.