### PR TITLE
Fix threat feed CLI help formatting

### DIFF
--- a/zeek/scripts/zeek_intel_from_threat_feed.py
+++ b/zeek/scripts/zeek_intel_from_threat_feed.py
@@ -47,8 +47,8 @@ def main():
                 ' - MISP default feeds: https://www.misp-project.org/feeds/',
                 ' - Managing MISP feeds: https://misp.gitbooks.io/misp-book/content/managing-feeds/',
                 ' - Expand MISP usage: https://github.com/idaholab/Malcolm/issues/336',
-                ' - Mandiant Threat Intelligence Indicators API: https://gtidocs.virustotal.com/reference/ioc-collection-object'
-                ' - Google Threat Intelligence IoC Collection API: https://gtidocs.virustotal.com/reference/ioc-collection-object'
+                ' - Mandiant Threat Intelligence Indicators API: https://gtidocs.virustotal.com/reference/ioc-collection-object',
+                ' - Google Threat Intelligence IoC Collection API: https://gtidocs.virustotal.com/reference/ioc-collection-object',
                 '',
                 'Note: The Zeek intelligence framework only supports simple indicators matched against a single value.',
                 'The STIX™ standard can express more complex indicators that cannot be expressed with Zeek intelligence items.',


### PR DESCRIPTION
## Summary

Fix the CLI help text in `zeek_intel_from_threat_feed.py`.

Two adjacent entries in the `argparse` description are missing commas, so Python concatenates the Mandiant and Google Threat Intelligence references instead of rendering them as separate help entries.

This adds the missing separators only. Runtime behaviour is unchanged.