### PR TITLE
Add RBAC coverage for OpenSearch proxy endpoint

### DIFF
--- a/nginx/lua/nginx_auth_helpers.lua
+++ b/nginx/lua/nginx_auth_helpers.lua
@@ -114,6 +114,11 @@ local path_role_envs = {
         "ROLE_ARKIME_WISE_READ_WRITE_ACCESS",
         "ROLE_READ_ACCESS",
         "ROLE_READ_WRITE_ACCESS"
+    }},
+
+    -- OpenSearch proxy
+    { pattern = "^/mapi/opensearch", roles = {
+        "ROLE_ADMIN"
     }}
 }
 


### PR DESCRIPTION
The `path_role_envs` table in `nginx/lua/nginx_auth_helpers.lua` covers `/auth`, `/arkime`, `/wise`, `/upload`, `/netbox`, `/extracted-files`, and `/dashboards`, but has no entry for `/mapi/opensearch/`. When RBAC is enabled, the default-allow fallback at line 460 grants any authenticated user access to the OpenSearch proxy regardless of their assigned role.

This adds an admin-only RBAC entry for `/mapi/opensearch`, restricting direct OpenSearch API access to users with `ROLE_ADMIN`. Non-admin users can still access session data through Dashboards and Arkime as intended.

Tested on v26.08.0 with `NGINX_AUTH_MODE=keycloak` and `ROLE_BASED_ACCESS=true`. Without this patch, a viewer-role user can query `_cat/nodes`, `_cluster/settings`, and `_snapshot` directly. With this patch, those requests return 403 for non-admin users.