### PR TITLE
Fix UFW manager path resolution on Hedgehog

### DIFF
--- a/scripts/control.py
+++ b/scripts/control.py
@@ -1539,10 +1539,10 @@ def start():
         if SYSTEM_INFO["malcolm_iso_install"] and dockerComposeYaml:
 
             # if we can control the UFW firewall clear it now
-            ufw_manager_cmd = 'ufw_manager.sh'
-            if not which(ufw_manager_cmd):
-                if os.path.isfile(os.path.join('/usr/local/bin/', ufw_manager_cmd)):
-                    ufw_manager_cmd = os.path.join('/usr/local/bin/', ufw_manager_cmd)
+            ufw_manager_cmd = shutil.which('ufw_manager.sh')
+            if not ufw_manager_cmd:
+                if os.path.isfile('/usr/local/bin/ufw_manager.sh'):
+                    ufw_manager_cmd = '/usr/local/bin/ufw_manager.sh'
                 else:
                     ufw_manager_cmd = None
 


### PR DESCRIPTION
## Summary
- resolve `ufw_manager.sh` to its full executable path before invoking it with `sudo`
- keep `/usr/local/bin/ufw_manager.sh` as the fallback

## Why
On Raspberry Pi-based Hedgehog systems, `control.py` can find `ufw_manager.sh` in the user's `PATH` but then invoke the bare command name with `sudo`. If sudo uses a different PATH, startup fails with `sudo: ufw_manager.sh: command not found`.

Using the resolved path also matches the existing sudoers rule for `/usr/local/bin/ufw_manager.sh`.

## Testing
- verified the branch is based directly on current `cisagov/Malcolm:main`
- verified the diff is limited to the UFW command-path resolution in `scripts/control.py`
- verified `shutil.which()` returns an absolute executable path for a command found in `PATH`

Fixes #1097
