### PR TITLE
Allow explicit public subnets for NetBox autopopulation

### DIFF
--- a/config/netbox-common.env.example
+++ b/config/netbox-common.env.example
@@ -7,10 +7,11 @@ NETBOX_ENRICHMENT=false
 NETBOX_DEFAULT_SITE=Malcolm
 # Whether or not unobserved network entities in Logstash data will be used to populate NetBox
 NETBOX_AUTO_POPULATE=false
-# Comma-separated list of private CIDR subnets to control NetBox IP autopopulation.
+# Comma-separated list of CIDR subnets to control NetBox IP autopopulation.
 #   See "Subnets considered for autopopulation" in the documentation for examples.
 # Behavior:
 #   * If left blank, *all private* IPv4 and IPv6 address ranges will be autopopulated.
+#   * Public CIDRs are eligible only when explicitly included.
 #   * Use an exclamation point (`!`) before a CIDR to explicitly *exclude* that subnet.
 #   * If only exclusions are listed, all private IPs are allowed *except* those excluded.
 #   * If both inclusions and exclusions are listed:

--- a/logstash/ruby/netbox_enrich.rb
+++ b/logstash/ruby/netbox_enrich.rb
@@ -136,10 +136,6 @@ def parse_autopopulate_config(raw_config)
     end
 
     range = cidr.to_range
-    unless range.first.private?
-      puts "parse_autopopulate_config skipping non-private CIDR: #{cidr_str}"
-      next
-    end
 
     entries << {
       cidr: cidr,
@@ -541,8 +537,6 @@ def autopopulate_allowed?(ip_input, site_id, config_site_hash)
          end
        end
 
-  return false unless ip.private?
-
   # Determine applicable config: site-specific first, fall back to '*', else allow
   config = config_site_hash[site_id]
   if config.nil? && (site_id.is_a?(Integer) || site_id.to_s.match?(/\A[+-]?\d+\z/)) && (site_id.to_i > 0)
@@ -555,11 +549,11 @@ def autopopulate_allowed?(ip_input, site_id, config_site_hash)
   end
   config = config_site_hash['*'] if config.nil?
 
-  return true if config.nil? || config[:allow_all_private]
+  return ip.private? if config.nil? || config[:allow_all_private]
 
-  # If no positive entries, but negatives exist, allow all except those excluded
+  # If no positive entries, but negatives exist, allow all private IPs except those excluded
   if config[:entries].none? { |e| e[:allow] } && !config[:entries].empty?
-    return !config[:entries].any? { |entry| entry[:cidr].include?(ip) }
+    return ip.private? && !config[:entries].any? { |entry| entry[:cidr].include?(ip) }
   end
 
   # Iterate entries in order; last matching rule wins
@@ -1570,7 +1564,7 @@ def netbox_lookup(
         _devices = lookup_devices(ip_key, site_id, _lookup_service_port, @netbox_url_base, @netbox_uri_suffix, _nb)
 
         if @autopopulate && (_devices.nil? || _devices.empty?)
-          # no results found, autopopulate enabled, private-space IP address...
+          # no results found, autopopulate enabled, eligible IP address...
           # let's create an entry for this device
           _autopopulate_device,
           _autopopulate_role,
@@ -1810,7 +1804,7 @@ def netbox_lookup(
                                                      _autopopulate_mac,
                                                      _nb)
     end # check if device was created and has ID
-  end # IP address is private IP
+  end # eligible IP address
 
   # yield return value for _lookup_hash getset
   return (!_lookup_result.nil? && !_lookup_result.empty?) ? _lookup_result : nil, _key_ip, _nb&.initialized? || false


### PR DESCRIPTION
## Summary
- allow public CIDRs in `NETBOX_AUTO_POPULATE_SUBNETS` when they are explicitly included
- preserve private-only behavior when the variable is blank
- keep exclusion-only configurations scoped to private address space
- document the explicit-public behavior in `netbox-common.env.example`

## Why
NetBox autopopulation currently discards non-private CIDRs during parsing and rejects non-private IPs before configured subnet rules are evaluated. This prevents organizations that own public address space from explicitly opting those ranges into autopopulation.

This change evaluates explicit positive CIDRs regardless of whether they are private or public while keeping the existing private-only default for unspecified ranges.

## Testing
- verified blank configuration allows private and rejects public IPs
- verified an explicitly included public CIDR is allowed while unrelated public IPs remain rejected
- verified exclusion-only rules still allow only private space outside excluded ranges
- verified mixed public include/exclude rules preserve last-match-wins behavior
- verified the GitHub diff is limited to the NetBox autopopulation eligibility logic and configuration comments

Fixes #908
