### PR TITLE
Prefer the most specific NetBox prefix for enrichment

### DIFF
--- a/logstash/ruby/netbox_enrich.rb
+++ b/logstash/ruby/netbox_enrich.rb
@@ -1787,6 +1787,10 @@ def netbox_lookup(
         end
       end
 
+      if (@lookup_type == :ip_prefix) && _prefixes.is_a?(Array) && !_prefixes.empty?
+        _prefixes = [_prefixes.max_by { |p| (IPAddr.new(p[:cidr].to_s).prefix rescue -1) }]
+      end
+
       # :cidr was only needed for most-specific-prefix selection above; drop it so
       #   the ip_prefix enrichment output shape is unchanged
       _prefixes.each { |p| p.delete(:cidr) if p.is_a?(Hash) } if _prefixes.is_a?(Array)


### PR DESCRIPTION
## Summary
- keep only the most specific matching NetBox prefix when enriching IP prefix fields
- prevent parent and child prefixes from producing duplicate/multi-valued segment metadata

## Why
NetBox's `contains` lookup can return multiple prefixes for the same IP when parent and child prefixes both exist. Malcolm currently writes all of those matches into the event, which can give `source.segment` and `destination.segment` multiple values and break visualizations.

Selecting the match with the longest prefix length keeps the child/more specific network. This also matches the existing most-specific-prefix behavior used for `purdue_zone` propagation in the same code path.

## Testing
- verified nested IPv4 prefixes select the longest prefix regardless of result order
- verified `/32` takes precedence over broader IPv4 prefixes
- verified nested IPv6 prefixes select the longest prefix
- verified the branch is based directly on current `cisagov/Malcolm:main`
- verified the final diff is limited to the NetBox prefix-selection logic

Fixes #591
