### PR TITLE
Add offline Zeek TLS decryption configuration

### DIFF
--- a/config/zeek-offline.env.example
+++ b/config/zeek-offline.env.example
@@ -6,6 +6,12 @@ ZEEK_AUTO_ANALYZE_PCAP_THREADS=1
 # Set to true to enable Zeek's ZAM script optimizer (-O ZAM)
 # https://docs.zeek.org/en/master/advanced/scripting/optimization.html
 ZEEK_ZAM=false
+# Path inside the Zeek container to a Zeek-formatted TLS key log file for
+#   decrypting supported TLS traffic during offline PCAP analysis. The key file
+#   can be placed under ./zeek/custom/, mounted at /usr/local/zeek/share/zeek/site/custom/.
+#   This expects Zeek's converted TSV format, not a raw SSLKEYLOGFILE.
+# https://docs.zeek.org/en/master/frameworks/tls-decryption.html
+ZEEK_TLS_KEYLOG_FILE=
 # Whether or not Zeek should analyze captured PCAP files captured
 #   by netsniff-ng/tcpdump (see PCAP_ENABLE_NETSNIFF and PCAP_ENABLE_TCPDUMP
 #   below). If ZEEK_LIVE_CAPTURE is true, this should be false: otherwise

--- a/zeek/custom/.gitignore
+++ b/zeek/custom/.gitignore
@@ -1,3 +1,5 @@
 *
 !.gitignore
+!__load__.zeek
+!tls-decryption.zeek
 

--- a/zeek/custom/__load__.zeek
+++ b/zeek/custom/__load__.zeek
@@ -1,0 +1,5 @@
+global zeek_tls_keylog_file = getenv("ZEEK_TLS_KEYLOG_FILE");
+
+@if (zeek_tls_keylog_file != "")
+  @load ./tls-decryption.zeek
+@endif

--- a/zeek/custom/tls-decryption.zeek
+++ b/zeek/custom/tls-decryption.zeek
@@ -1,0 +1,13 @@
+@load protocols/ssl/decryption
+@load base/protocols/http
+
+event zeek_init()
+  {
+  suspend_processing();
+  }
+
+event Input::end_of_data(name: string, source: string)
+  {
+  if ( name == "tls-keylog-file" )
+    continue_processing();
+  }


### PR DESCRIPTION
## Summary
- expose `ZEEK_TLS_KEYLOG_FILE` for offline Zeek PCAP analysis
- conditionally load Zeek's TLS decryption policy only when a key file is configured
- suspend offline processing until the TLS key file has finished loading
- keep user key material under `zeek/custom/` ignored by Git

## Why
Issue #471 asks for configuration and enablement of Zeek TLS decryption. Zeek documents trace-file decryption as the common supported workflow, while live decryption requires separate real-time key transport.

This adds the practical offline path for uploaded PCAP analysis without changing live capture behavior.

## Usage
1. Convert the raw `SSLKEYLOGFILE` to Zeek's TSV key-log format as described in the Zeek TLS decryption documentation.
2. Place the converted file under `./zeek/custom/`, for example `tls-keylog.log`.
3. Set `ZEEK_TLS_KEYLOG_FILE=/usr/local/zeek/share/zeek/site/custom/tls-keylog.log` in `config/zeek-offline.env`.
4. Process the matching PCAP with Zeek as usual.

## Validation
- verified `zeek-offline.env` is only applied to the offline Zeek service
- verified Malcolm's `local.zeek` already loads the `custom` policy directory
- kept the helper policy aligned with Zeek's documented suspend/load/resume example
- verified the branch is based directly on current `cisagov/Malcolm:main`
- verified the final diff is limited to four Zeek configuration/policy files

Addresses #471
