### PR TITLE
Fix JA4 package version pin

### DIFF
--- a/zeek/scripts/zeek_install_plugins.sh
+++ b/zeek/scripts/zeek_install_plugins.sh
@@ -149,7 +149,7 @@ ZKG_GITHUB_URLS=(
   "https://github.com/corelight/zeek-xor-exe-plugin|master"
   "https://github.com/corelight/zerologon"
   "https://github.com/cybera/zeek-sniffpass"
-  "https://github.com/FoxIO-LLC/ja4|40aa9321be95793cc361ba1edd6cf14f12707486"
+  "https://github.com/FoxIO-LLC/ja4|v1.0.1"
   "https://github.com/J-Gras/zeek-fuzzy-hashing|topic/jgras/hash-all-files"
   "https://github.com/mmguero-dev/bzar"
   "https://github.com/corelight/json-streaming-logs|master"


### PR DESCRIPTION
Fixes #1109.

Replace the raw JA4 commit pin with the v1.0.1 release tag. The tag contains the previously pinned commit and preserves the Zeek field layout Malcolm depends on, while remaining resolvable by zkg after the upstream repository advances.

Validation:
- confirmed the old commit SHA is rejected by zkg as an invalid package version
- confirmed JA4 v1.0.1 installs and loads successfully with zkg in a Zeek container
- git diff --check
