### PR TITLE
Run file-watcher worker in pool thread instead of inline

### DIFF
--- a/shared/bin/pcap_watcher.py
+++ b/shared/bin/pcap_watcher.py
@@ -556,7 +556,8 @@ def main():
         workerThreadCount = malcolm_utils.AtomicInt(value=0)
         ThreadPool(
             1,
-            watch_common.ProcessFileEventWorker(
+            watch_common.ProcessFileEventWorker,
+            (
                 [
                     handler,
                     observer,

--- a/shared/bin/watch_common.py
+++ b/shared/bin/watch_common.py
@@ -309,7 +309,8 @@ def WatchAndProcessDirectory(
         workerThreadCount = AtomicInt(value=0)
         ThreadPool(
             1,
-            ProcessFileEventWorker(
+            ProcessFileEventWorker,
+            (
                 [
                     handler,
                     observer,


### PR DESCRIPTION
`watch_common.py` and `pcap_watcher.py` called `ThreadPool(1, ProcessFileEventWorker([...]))` — with parentheses, so the blocking worker loop executed inline in the calling thread and its return value (`None`) went to the pool as the initializer. The pool thread sat idle while the supervising `observer.join()` loop below never ran until the worker exited.

Every other `ThreadPool` call in the repo (`pcap_processor.py`, …) passes the function reference plus an args tuple — this just matches that shape: `ThreadPool(1, ProcessFileEventWorker, ([...],))`.

Verified with the real worker function: before, it ran in the caller thread; after, it runs in a pool thread. Both files compile.