### PR TITLE
Reject failed threat-feed downloads instead of saving error pages

### DIFF
--- a/zeek/scripts/zeek_threat_feed_utils.py
+++ b/zeek/scripts/zeek_threat_feed_utils.py
@@ -225,6 +225,9 @@ def download_to_file(url, session=None, local_filename=None, chunk_bytes=4096, s
         if session is None
         else session.get(url, stream=True, allow_redirects=True, verify=ssl_verify)
     )
+    # Don't save error pages to disk as if they were the feed: raise here
+    # like get_url_paths() does (the caller logs and skips the URL).
+    r.raise_for_status()
     with open(tmpDownloadedFileSpec, "wb") as f:
         for chunk in r.iter_content(chunk_size=chunk_bytes):
             if chunk:


### PR DESCRIPTION
`download_to_file()` wrote whatever the server returned straight to disk without checking the status — a 404 HTML page came back as a valid feed-file path and got parsed as feed lines. Reproduced locally against a stub server: before, the 404 body was saved and returned; after `r.raise_for_status()`, it raises (the caller already catches `Exception`, logs, and skips the URL).

This mirrors the sibling `get_url_paths()` in the same file, which already does `response.ok` / `raise_for_status()`.