### PR TITLE
Preserve imported configuration choices

### DIFF
--- a/scripts/installer/core/malcolm_config.py
+++ b/scripts/installer/core/malcolm_config.py
@@ -186,7 +186,7 @@ class MalcolmConfig(ObservableStoreMixin):
         return self._dependency_manager.get_dependency_info(key)
 
     def get_env_var_by_item_key(self, key: str) -> List[EnvVariable]:
-        """Lookup the environment variable(s) for a given configuration item key"""
+        """Lookup the environment variable(s) for a given item key"""
         return self._env_mapper.get_env_var_by_item_key(key)
 
     def get_all_config_items(self, modified_only: bool = False) -> Dict[str, ConfigItem]:
@@ -248,6 +248,7 @@ class MalcolmConfig(ObservableStoreMixin):
         key: str,
         value: Any,
         ignore_errors: Optional[bool] = False,
+        track_modified: Optional[bool] = True,
     ) -> None:
         """Set the value of a configuration item.
 
@@ -256,6 +257,8 @@ class MalcolmConfig(ObservableStoreMixin):
             value: New value to set
             ignore_errors: silently ignore errors rather than raising (meaning the
                            value may *not* have been set)
+            track_modified: include the key in the interactive change summary. Imported
+                            values can set this false while still remaining explicit.
 
         Raises:
             ConfigItemNotFoundError: If the key does not exist.
@@ -274,7 +277,7 @@ class MalcolmConfig(ObservableStoreMixin):
             if not success:
                 raise ConfigValueValidationError(key, value, error_message)
 
-            if key not in self._modified_keys:
+            if track_modified and key not in self._modified_keys:
                 self._modified_keys.append(key)
 
             self._notify_observers(key, item.get_value())
@@ -554,7 +557,11 @@ class MalcolmConfig(ObservableStoreMixin):
             if winner_value == "" and not ((item := self._items.get(item_key)) and item.accept_blank):
                 continue
             try:
-                self.apply_default(item_key, winner_value, ignore_errors=True)
+                winner_env = self._env_mapper.get_env_variable(winner_env_key) if winner_env_key else None
+                if winner_env and winner_env.is_authoritative_for(item_key):
+                    self.set_value(item_key, winner_value, ignore_errors=True, track_modified=False)
+                else:
+                    self.apply_default(item_key, winner_value, ignore_errors=True)
             except (ConfigItemNotFoundError, ConfigValueValidationError) as e:
                 if "unittest" not in sys.modules:
                     InstallerLogger.warning(f"Could not set config for {item_key} from env: {e}")
@@ -929,7 +936,7 @@ class MalcolmConfig(ObservableStoreMixin):
         """Get the chain of dependencies that need to be satisfied for an item to be visible.
 
         Args:
-            key: The configuration item key
+            key: Configuration item key
 
         Returns:
             List of keys representing the dependency chain from root to this item

--- a/scripts/installer/tests/unit/test_imported_dependency_values.py
+++ b/scripts/installer/tests/unit/test_imported_dependency_values.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+import json
+import os
+import tempfile
+import unittest
+
+from scripts.malcolm_constants import PROFILE_HEDGEHOG
+from scripts.installer.configs.constants.config_env_var_keys import (
+    KEY_ENV_ARKIME_LIVE_CAPTURE,
+    KEY_ENV_PROFILE_KEY,
+    KEY_ENV_ZEEK_LIVE_CAPTURE,
+)
+from scripts.installer.configs.constants.configuration_item_keys import (
+    KEY_CONFIG_ITEM_CAPTURE_LIVE_NETWORK_TRAFFIC,
+    KEY_CONFIG_ITEM_LIVE_ARKIME,
+    KEY_CONFIG_ITEM_LIVE_ZEEK,
+    KEY_CONFIG_ITEM_MALCOLM_PROFILE,
+)
+from scripts.installer.core.malcolm_config import MalcolmConfig
+from scripts.installer.utils.settings_file_handler import SettingsFileHandler
+
+
+class TestImportedDependencyValues(unittest.TestCase):
+    def test_authoritative_env_value_survives_dependency_updates(self):
+        cfg = MalcolmConfig()
+        candidates = {
+            KEY_CONFIG_ITEM_LIVE_ARKIME: [(KEY_ENV_ARKIME_LIVE_CAPTURE, False)],
+            KEY_CONFIG_ITEM_MALCOLM_PROFILE: [(KEY_ENV_PROFILE_KEY, PROFILE_HEDGEHOG)],
+            KEY_CONFIG_ITEM_CAPTURE_LIVE_NETWORK_TRAFFIC: [(KEY_ENV_ZEEK_LIVE_CAPTURE, True)],
+            KEY_CONFIG_ITEM_LIVE_ZEEK: [(KEY_ENV_ZEEK_LIVE_CAPTURE, True)],
+        }
+
+        cfg._apply_env_candidates(candidates)
+
+        self.assertFalse(cfg.get_value(KEY_CONFIG_ITEM_LIVE_ARKIME))
+        self.assertTrue(cfg.get_item(KEY_CONFIG_ITEM_LIVE_ARKIME).is_modified)
+        self.assertNotIn(KEY_CONFIG_ITEM_LIVE_ARKIME, cfg.get_all_config_items(modified_only=True))
+
+    def test_settings_file_values_are_explicit_but_not_reported_as_changes(self):
+        cfg = MalcolmConfig()
+        settings = {
+            "configuration": {
+                KEY_CONFIG_ITEM_LIVE_ARKIME: False,
+                KEY_CONFIG_ITEM_MALCOLM_PROFILE: PROFILE_HEDGEHOG,
+                KEY_CONFIG_ITEM_CAPTURE_LIVE_NETWORK_TRAFFIC: True,
+                KEY_CONFIG_ITEM_LIVE_ZEEK: True,
+            }
+        }
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            path = os.path.join(temp_dir, "settings.json")
+            with open(path, "w") as f:
+                json.dump(settings, f)
+
+            missing = SettingsFileHandler(cfg).load_from_file(path, config_only=True)
+
+        self.assertFalse(cfg.get_value(KEY_CONFIG_ITEM_LIVE_ARKIME))
+        self.assertTrue(cfg.get_item(KEY_CONFIG_ITEM_LIVE_ARKIME).is_modified)
+        self.assertNotIn(KEY_CONFIG_ITEM_LIVE_ARKIME, missing["missing_configuration"])
+        self.assertNotIn(KEY_CONFIG_ITEM_LIVE_ARKIME, cfg.get_all_config_items(modified_only=True))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/installer/utils/settings_file_handler.py
+++ b/scripts/installer/utils/settings_file_handler.py
@@ -252,8 +252,8 @@ class SettingsFileHandler:
                     if value == CONFIG_ITEM_NONE_SENTINEL:
                         InstallerLogger.debug(f"Skipping configuration item {key} (sentinel value)")
                         continue
-                    # delegate normalization and validation to MalcolmConfig
-                    self.malcolm_config.apply_default(key, value)
+                    # Treat persisted values as explicit without adding them to the interactive change summary.
+                    self.malcolm_config.set_value(key, value, track_modified=False)
                     InstallerLogger.debug(f"Set configuration item {key} = {value}")
                 except Exception as e:
                     InstallerLogger.warning(f"Failed to set configuration item {key}: {e}")


### PR DESCRIPTION
## Summary

- Preserve authoritative `.env` and imported JSON/YAML values during dependency evaluation.
- Keep imported values out of the interactive change summary.
- Leave derived environment values eligible for dependency defaults.
- Add regression tests for Hedgehog live-capture imports.

Fixes #949