### PR TITLE
Fall back to tcpdump when Arkime live capture is unavailable

### DIFF
--- a/Dockerfiles/arkime.Dockerfile
+++ b/Dockerfiles/arkime.Dockerfile
@@ -138,6 +138,7 @@ RUN export DEBARCH=$(dpkg --print-architecture) && \
       python3-setuptools \
       python3-wheel \
       rsync \
+      tcpdump \
       tini \
       wget \
       zlib1g && \

--- a/arkime/scripts/live_capture.sh
+++ b/arkime/scripts/live_capture.sh
@@ -48,7 +48,7 @@ function tcpdump_fallback() {
     [[ -n "${PCAP_FILTER}" ]] && filter_args+=( "${PCAP_FILTER}" )
 
     echo "Falling back to local tcpdump capture on ${PCAP_IFACE}"
-    pushd /data/pcap >/dev/null 2>&1 || return 1
+    pushd /data/pcap/upload >/dev/null 2>&1 || return 1
 
     for iface in ${PCAP_IFACE//,/ }; do
         /usr/bin/tcpdump \

--- a/arkime/scripts/live_capture.sh
+++ b/arkime/scripts/live_capture.sh
@@ -10,12 +10,84 @@ function urlencodeall() {
     done
 }
 
+function arkime_backend_ready() {
+    curl "${CURL_CONFIG_PARAMS[@]}" --connect-timeout 2 --max-time 5 -fs \
+      -H'Content-Type: application/json' -XGET \
+      "${OPENSEARCH_URL}/_index_template/malcolm_template" 2>/dev/null | grep -q index_templates || return 1
+
+    (( $(curl "${CURL_CONFIG_PARAMS[@]}" --connect-timeout 2 --max-time 5 -fs \
+      -H'Content-Type: application/json' -XGET \
+      "${OPENSEARCH_URL}/_cat/indices/arkime_users_v*" 2>/dev/null | wc -l) >= 1 ))
+}
+
+function wait_for_arkime_backend() {
+    local wait_started=${SECONDS}
+
+    until arkime_backend_ready; do
+        if (( ARKIME_LIVE_CAPTURE_FALLBACK_SECONDS > 0 )) && \
+           (( SECONDS - wait_started >= ARKIME_LIVE_CAPTURE_FALLBACK_SECONDS )); then
+            return 1
+        fi
+        sleep 1
+    done
+}
+
+function tcpdump_fallback() {
+    local iface
+    local status
+    local rotate_seconds
+    local -a filter_args=()
+    local -a tcpdump_pids=()
+
+    if [[ -z "${PCAP_IFACE}" ]]; then
+        echo "Cannot start tcpdump fallback: PCAP_IFACE is empty" >&2
+        return 1
+    fi
+
+    rotate_seconds=$(( PCAP_ROTATE_MINUTES * 60 ))
+    [[ -n "${PCAP_FILTER}" ]] && filter_args+=( "${PCAP_FILTER}" )
+
+    echo "Falling back to local tcpdump capture on ${PCAP_IFACE}"
+    pushd /data/pcap >/dev/null 2>&1 || return 1
+
+    for iface in ${PCAP_IFACE//,/ }; do
+        /usr/bin/tcpdump \
+          -i "${iface}" \
+          -j host \
+          -s "${PCAP_SNAPLEN}" \
+          -w "mtcpdump-${iface}_${PCAP_TCPDUMP_FILENAME_PATTERN}" \
+          -G "${rotate_seconds}" \
+          -C "${PCAP_ROTATE_MEGABYTES}" \
+          -K \
+          -n \
+          -Z "${PUSER}" \
+          "${filter_args[@]}" &
+        tcpdump_pids+=( "$!" )
+    done
+
+    wait -n "${tcpdump_pids[@]}"
+    status=$?
+    kill "${tcpdump_pids[@]}" >/dev/null 2>&1 || true
+    wait "${tcpdump_pids[@]}" >/dev/null 2>&1 || true
+    popd >/dev/null 2>&1
+    return "${status}"
+}
+
 ARKIME_DIR=${ARKIME_DIR:-"/opt/arkime"}
 ARKIME_CONFIG_FILE="${ARKIME_DIR}"/etc/config.ini
 CERT_FILE="${ARKIME_DIR}"/etc/viewer.crt
 KEY_FILE="${ARKIME_DIR}"/etc/viewer.key
 PUSER=${PUSER:-"arkime"}
 PGROUP=${PGROUP:-"arkime"}
+
+ARKIME_LIVE_CAPTURE_FALLBACK_SECONDS=${ARKIME_LIVE_CAPTURE_FALLBACK_SECONDS:-300}
+[[ "${ARKIME_LIVE_CAPTURE_FALLBACK_SECONDS}" =~ ^[0-9]+$ ]] || ARKIME_LIVE_CAPTURE_FALLBACK_SECONDS=300
+PCAP_IFACE=${PCAP_IFACE:-}
+PCAP_FILTER=${PCAP_FILTER:-}
+PCAP_ROTATE_MINUTES=${PCAP_ROTATE_MINUTES:-10}
+PCAP_ROTATE_MEGABYTES=${PCAP_ROTATE_MEGABYTES:-4096}
+PCAP_SNAPLEN=${PCAP_SNAPLEN:-0}
+PCAP_TCPDUMP_FILENAME_PATTERN=${PCAP_TCPDUMP_FILENAME_PATTERN:-%Y%m%d%H%M%S.pcap}
 
 OPENSEARCH_PRIMARY=${OPENSEARCH_PRIMARY:-"opensearch-local"}
 OPENSEARCH_URL=${OPENSEARCH_URL:-"https://opensearch:9200"}
@@ -68,14 +140,14 @@ if [[ -n "${EXTRA_TAGS}" ]]; then
   done < <(echo "${EXTRA_TAGS}" | tr ',' '\n') # loop over ',' separated EXTRA_TAGS values
 fi
 
-# wait patiently for the non-live Arkime to initialize the database
-echo "Giving $OPENSEARCH_PRIMARY time to start..."
-/usr/local/bin/opensearch_status.sh -t malcolm_template 2>&1 && echo "$OPENSEARCH_PRIMARY is running!"
-echo "Giving Arkime time to initialize..."
-sleep 5
-until (( $(curl "${CURL_CONFIG_PARAMS[@]}" -fs -XGET -H'Content-Type: application/json' "${OPENSEARCH_URL}/_cat/indices/arkime_users_v*" | wc -l) >= 1 )); do
-    sleep 1
-done
+# wait for the non-live Arkime to initialize the database
+echo "Waiting for $OPENSEARCH_PRIMARY and Arkime initialization..."
+if ! wait_for_arkime_backend; then
+    echo "Arkime backend did not become ready within ${ARKIME_LIVE_CAPTURE_FALLBACK_SECONDS} seconds"
+    tcpdump_fallback
+    exit $?
+fi
+echo "$OPENSEARCH_PRIMARY and Arkime are ready!"
 
 # set (or remove) wiseURL and wise.so in config file
 if [ -z "${ARKIME_WISE_SERVICE_URL+x}" ]; then
@@ -164,3 +236,12 @@ echo
   -o dropGroup=${PGROUP} \
   -o ecsEventProvider=arkime \
   -o ecsEventDataset=session
+CAPTURE_STATUS=$?
+
+if (( ARKIME_LIVE_CAPTURE_FALLBACK_SECONDS > 0 )); then
+    echo "Arkime live capture exited with status ${CAPTURE_STATUS}"
+    tcpdump_fallback
+    exit $?
+fi
+
+exit "${CAPTURE_STATUS}"

--- a/config/arkime-live.env.example
+++ b/config/arkime-live.env.example
@@ -2,6 +2,10 @@
 #   interface (PCAP_IFACE in pcap-capture.env specifies interface)
 ARKIME_LIVE_CAPTURE=false
 
+# Seconds to wait for the Arkime backend before falling back to local tcpdump capture.
+#   A value of 0 disables the tcpdump fallback.
+ARKIME_LIVE_CAPTURE_FALLBACK_SECONDS=300
+
 # Live capture tuning parameters
 ARKIME_COMPRESSION_TYPE=none
 ARKIME_COMPRESSION_LEVEL=0


### PR DESCRIPTION
## Summary

- Fall back to local `tcpdump` if the Arkime backend remains unavailable or Arkime capture exits.
- Write fallback PCAPs into the existing `pcap/upload` processing path.
- Reuse configured interfaces, filters, rotation size and interval.
- Add a configurable fallback timeout; `0` disables it.
- Install `tcpdump` in the `arkime-live` image.

Fixes #665